### PR TITLE
docs: link the org-wide CONTRIBUTING guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ dist-tags remain after the PR closes as convenience aliases; use the exact
 canary version from the PR comment for reproducible installs.
 
 Before publishing, read [Publishing](docs/PUBLISHING.md).
+
+## Contributing
+
+Org-wide conventions — where to open PRs, release labels, shared CI — live in the [Datasworn Community CONTRIBUTING guide](https://github.com/datasworn-community/.github/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
Adds a **Contributing** section pointing at the org-wide [CONTRIBUTING guide](https://github.com/datasworn-community/.github/blob/main/CONTRIBUTING.md), per Scott's review on datasworn-community/.github#9 ("add a link to this from the profile README and probably the downstream content packages").

Note: the linked file lands when .github#9 merges — merge that one first.