### PR TITLE
chore(deps): bump @datasworn-community/core and build-tools to 0.2.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,23 +5,23 @@
     "": {
       "name": "@datasworn-community/datasworn-elegy",
       "devDependencies": {
-        "@datasworn-community/build-tools": "0.2.8",
-        "@datasworn-community/core": "0.2.8",
+        "@datasworn-community/build-tools": "0.2.10",
+        "@datasworn-community/core": "0.2.10",
         "@datasworn-community/ironsworn-classic": "0.2.1",
         "@datasworn-community/starforged": "0.2.1",
       },
     },
   },
   "packages": {
-    "@datasworn-community/build-tools": ["@datasworn-community/build-tools@0.2.8", "", { "dependencies": { "@sinclair/typebox": "0.34.41", "ajv": "^8.20.0", "ajv-formats": "^3.0.1", "lodash-es": "^4.18.1", "yaml": "^2.9.0" }, "peerDependencies": { "@datasworn-community/core": "0.2.8" }, "bin": { "datasworn-build": "dist/cli/datasworn-build.js", "datasworn-migrate": "dist/cli/datasworn-migrate.js" } }, "sha512-W514BVPANbuC6pMYVvaO5QiulVhxxDZn1FYojbq6aY+FmniLDY4nbUA3Fe1X5MJcGBLzuh4DTn6cMgRxv3mdSQ=="],
+    "@datasworn-community/build-tools": ["@datasworn-community/build-tools@0.2.10", "", { "dependencies": { "@sinclair/typebox": "0.34.52", "ajv": "^8.20.0", "ajv-formats": "^3.0.1", "lodash-es": "^4.18.1", "yaml": "^2.9.0" }, "peerDependencies": { "@datasworn-community/core": "0.2.10" }, "bin": { "datasworn-build": "dist/cli/datasworn-build.js", "datasworn-migrate": "dist/cli/datasworn-migrate.js" } }, "sha512-n+8fcgSx1B9bi91J9cDyhzx1g3GMdKirWB71fsdCygQjulKRLvcsTHOvrMeGClKosoeXvwVMMef183hkbWen5A=="],
 
-    "@datasworn-community/core": ["@datasworn-community/core@0.2.8", "", {}, "sha512-aXv1iQ/ZRZArpz8/URp6eo1h+abWUL24b0qwFBSNFWQ0GDXNqfC1XM2I54bqshJMBMAvzrtP9/yK6qQhOdtcKA=="],
+    "@datasworn-community/core": ["@datasworn-community/core@0.2.10", "", {}, "sha512-pl2CEm0Np7KO6m5U7CvDSlRxxilOptkOxth/LQ6H3AiNz5dwXYCKVyn4sDp5klnzpgN7iNF1hPXCfaOHZu5UUw=="],
 
     "@datasworn-community/ironsworn-classic": ["@datasworn-community/ironsworn-classic@0.2.1", "", { "dependencies": { "@datasworn-community/core": "^0.2.0" } }, "sha512-FviRoSaVsvorZ/Y8tLtOkFxxwZx4LAFk9OyMBTHdSOH1EyoiIEf3iLfRog1arGBQZZXwM0l/awWVNHD+8gLqrg=="],
 
     "@datasworn-community/starforged": ["@datasworn-community/starforged@0.2.1", "", { "dependencies": { "@datasworn-community/core": "^0.2.0" } }, "sha512-ZplAnmlG6vSetpnzujXIlNdIMBvcwZ71WSbabScvmTkgMXxG5nBYWXFYIjONNIAWaDK+6mEge/MHneJnqOYKpQ=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.41", "", {}, "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g=="],
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -38,5 +38,9 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@datasworn-community/ironsworn-classic/@datasworn-community/core": ["@datasworn-community/core@0.2.8", "", {}, "sha512-aXv1iQ/ZRZArpz8/URp6eo1h+abWUL24b0qwFBSNFWQ0GDXNqfC1XM2I54bqshJMBMAvzrtP9/yK6qQhOdtcKA=="],
+
+    "@datasworn-community/starforged/@datasworn-community/core": ["@datasworn-community/core@0.2.8", "", {}, "sha512-aXv1iQ/ZRZArpz8/URp6eo1h+abWUL24b0qwFBSNFWQ0GDXNqfC1XM2I54bqshJMBMAvzrtP9/yK6qQhOdtcKA=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "bun": ">=1.3"
   },
   "devDependencies": {
-    "@datasworn-community/build-tools": "0.2.8",
-    "@datasworn-community/core": "0.2.8",
+    "@datasworn-community/build-tools": "0.2.10",
+    "@datasworn-community/core": "0.2.10",
     "@datasworn-community/ironsworn-classic": "0.2.1",
     "@datasworn-community/starforged": "0.2.1"
   }


### PR DESCRIPTION
Picks up `@datasworn-community/core` and `@datasworn-community/build-tools` **0.2.10**, published today after the release pipeline in `datasworn-community/datasworn` was unblocked. This repo was pinned at **0.2.8**.

Background: the auto-release job there had been failing on every releasable merge since 2026-07-08, when a branch ruleset started rejecting the version-bump push. Eight runs failed that way and no release shipped between v0.2.9 (07-04) and v0.2.10 today. Fixed in [datasworn#35](https://github.com/datasworn-community/datasworn/pull/35).

## Verification

Run locally on this branch:

- `bun install` — resolves both to 0.2.10
- `bun run build` — succeeds
- `bun run validate` — passes
- **`generated-datasworn/` is byte-identical** to what's committed. The only changed files are `package.json` and `bun.lock`, so this is a pure dependency bump with no content drift.
