### PR TITLE
feat: add Datasworn 0.3 world for Elegy

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,21 +5,21 @@
     "": {
       "name": "@datasworn-community/datasworn-elegy",
       "devDependencies": {
-        "@datasworn-community/build-tools": "0.2.10",
-        "@datasworn-community/core": "0.2.10",
-        "@datasworn-community/ironsworn-classic": "0.2.1",
-        "@datasworn-community/starforged": "0.2.1",
+        "@datasworn-community/build-tools": "0.3.0",
+        "@datasworn-community/core": "0.3.0",
+        "@datasworn-community/ironsworn-classic": "0.3.0",
+        "@datasworn-community/starforged": "0.3.0",
       },
     },
   },
   "packages": {
-    "@datasworn-community/build-tools": ["@datasworn-community/build-tools@0.2.10", "", { "dependencies": { "@sinclair/typebox": "0.34.52", "ajv": "^8.20.0", "ajv-formats": "^3.0.1", "lodash-es": "^4.18.1", "yaml": "^2.9.0" }, "peerDependencies": { "@datasworn-community/core": "0.2.10" }, "bin": { "datasworn-build": "dist/cli/datasworn-build.js", "datasworn-migrate": "dist/cli/datasworn-migrate.js" } }, "sha512-n+8fcgSx1B9bi91J9cDyhzx1g3GMdKirWB71fsdCygQjulKRLvcsTHOvrMeGClKosoeXvwVMMef183hkbWen5A=="],
+    "@datasworn-community/build-tools": ["@datasworn-community/build-tools@0.3.0", "", { "dependencies": { "@sinclair/typebox": "0.34.52", "ajv": "^8.20.0", "ajv-formats": "^3.0.1", "lodash-es": "^4.18.1", "yaml": "^2.9.0" }, "peerDependencies": { "@datasworn-community/core": "0.3.0" }, "bin": { "datasworn-build": "dist/cli/datasworn-build.js", "datasworn-migrate": "dist/cli/datasworn-migrate.js" } }, "sha512-01TYNOrw9jTSFL2AFh6ERXB7Y7yrBbRsTRoayF4CSBffvcOzxQdYwKogcdHkENTMLkPDzzuYtel2zpt4JtkXeQ=="],
 
-    "@datasworn-community/core": ["@datasworn-community/core@0.2.10", "", {}, "sha512-pl2CEm0Np7KO6m5U7CvDSlRxxilOptkOxth/LQ6H3AiNz5dwXYCKVyn4sDp5klnzpgN7iNF1hPXCfaOHZu5UUw=="],
+    "@datasworn-community/core": ["@datasworn-community/core@0.3.0", "", {}, "sha512-z0MteE8eNROM44NInAt5RpXqa6gZm0ixs34ARsl+b2VkQI+BXy7OsTtTOeAtvggMi+xnvmME9F7IIqPh+aCFiA=="],
 
-    "@datasworn-community/ironsworn-classic": ["@datasworn-community/ironsworn-classic@0.2.1", "", { "dependencies": { "@datasworn-community/core": "^0.2.0" } }, "sha512-FviRoSaVsvorZ/Y8tLtOkFxxwZx4LAFk9OyMBTHdSOH1EyoiIEf3iLfRog1arGBQZZXwM0l/awWVNHD+8gLqrg=="],
+    "@datasworn-community/ironsworn-classic": ["@datasworn-community/ironsworn-classic@0.3.0", "", { "dependencies": { "@datasworn-community/core": "^0.3.0" } }, "sha512-PDKgEkVHkV0oYtw6kBfbRVOSHnqLSOq1nC5ZiHYX9wilClSzxKqHifV5Ovu2TssMb/lgwmrKZm2HQvOcOSGUow=="],
 
-    "@datasworn-community/starforged": ["@datasworn-community/starforged@0.2.1", "", { "dependencies": { "@datasworn-community/core": "^0.2.0" } }, "sha512-ZplAnmlG6vSetpnzujXIlNdIMBvcwZ71WSbabScvmTkgMXxG5nBYWXFYIjONNIAWaDK+6mEge/MHneJnqOYKpQ=="],
+    "@datasworn-community/starforged": ["@datasworn-community/starforged@0.3.0", "", { "dependencies": { "@datasworn-community/core": "^0.3.0" } }, "sha512-sjdS3AkwO7wk8XMgU5KM28psjdgtShQO9r1BtalI8AOr/7u1wARzS6SERFSiIe9O2zcLr0JKEZM108dXFdeT3w=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 
@@ -38,9 +38,5 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
-
-    "@datasworn-community/ironsworn-classic/@datasworn-community/core": ["@datasworn-community/core@0.2.8", "", {}, "sha512-aXv1iQ/ZRZArpz8/URp6eo1h+abWUL24b0qwFBSNFWQ0GDXNqfC1XM2I54bqshJMBMAvzrtP9/yK6qQhOdtcKA=="],
-
-    "@datasworn-community/starforged/@datasworn-community/core": ["@datasworn-community/core@0.2.8", "", {}, "sha512-aXv1iQ/ZRZArpz8/URp6eo1h+abWUL24b0qwFBSNFWQ0GDXNqfC1XM2I54bqshJMBMAvzrtP9/yK6qQhOdtcKA=="],
   }
 }

--- a/datasworn.config.yaml
+++ b/datasworn.config.yaml
@@ -9,8 +9,8 @@ packages:
     type: ruleset
     source: source_data/elegy
     packageName: "@datasworn-community/elegy"
-    schemaLine: "0.2"
-    version: "0.2.0"
+    schemaLine: "0.3"
+    version: "0.3.0"
     description: "Datasworn JSON data for Elegy, a solo roleplaying game of vampires."
     license: "CC-BY-NC-SA-4.0"
     dependencies:
@@ -19,7 +19,7 @@ packages:
     publishDependencies:
       - id: classic
         packageName: "@datasworn-community/ironsworn-classic"
-        schemaLine: "0.2"
+        schemaLine: "0.3"
       - id: starforged
         packageName: "@datasworn-community/starforged"
-        schemaLine: "0.2"
+        schemaLine: "0.3"

--- a/docs/CONTENT_AUTHORING.md
+++ b/docs/CONTENT_AUTHORING.md
@@ -15,7 +15,7 @@ type: expansion
 ruleset: starforged
 ```
 
-For schema generation `0.2`, build-tools accepts compatible `0.1.0` source YAML
+For schema generation `0.3`, build-tools accepts compatible `0.1.0` source YAML
 and normalizes generated output to the installed schema version.
 
 Use a shared source block for attribution:
@@ -31,6 +31,24 @@ Use a shared source block for attribution:
 ```
 
 Then attach `_source: *Source` to collections and entries.
+
+## World Authoring
+
+Worlds group named truths in presentation order. Define the truths and reference
+them from a `worlds` entry:
+
+```yaml
+worlds:
+  home:
+    name: Home World
+    _source: *Source
+    truths:
+      - truth:my_package/iron
+    type: world
+```
+
+The builder assigns each world an ID from its package and key, such as
+`world:my_package/home`. A world must reference at least one unique truth ID.
 
 ## IDs and References
 
@@ -57,13 +75,13 @@ Use one of these package IDs in `dependencies` and `publishDependencies`:
 ```yaml
 - id: starforged
   packageName: "@datasworn-community/starforged"
-  schemaLine: "0.2"
+  schemaLine: "0.3"
 ```
 
 ```yaml
 - id: classic
   packageName: "@datasworn-community/ironsworn-classic"
-  schemaLine: "0.2"
+  schemaLine: "0.3"
 ```
 
 Add the same npm package to `devDependencies` so local builds can validate

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -42,10 +42,10 @@ dependencies:
 publishDependencies:
   - id: classic
     packageName: "@datasworn-community/ironsworn-classic"
-    schemaLine: "0.2"
+    schemaLine: "0.3"
   - id: starforged
     packageName: "@datasworn-community/starforged"
-    schemaLine: "0.2"
+    schemaLine: "0.3"
 ```
 
 Keep both official packages in `devDependencies` so local builds can validate

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -22,10 +22,10 @@ packages.
 Package versions use the Datasworn schema line:
 
 ```text
-0.2.0
+0.3.0
 ```
 
-For schema line `0.2`, content packages publish as `0.2.x`.
+For schema line `0.3`, content packages publish as `0.3.x`.
 
 ## Experimental Releases
 

--- a/generated-datasworn/elegy.json
+++ b/generated-datasworn/elegy.json
@@ -2610,7 +2610,7 @@
       "name": "moro de oliveira"
     }
   ],
-  "datasworn_version": "0.2.0",
+  "datasworn_version": "0.3.0",
   "date": "2024-07-31",
   "delve_sites": {},
   "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
@@ -13598,5 +13598,39 @@
     }
   },
   "type": "ruleset",
-  "url": "https://miraclem.itch.io/elegy"
+  "url": "https://miraclem.itch.io/elegy",
+  "worlds": {
+    "santa_maria": {
+      "_id": "world:elegy/santa_maria",
+      "_source": {
+        "authors": [
+          {
+            "name": "moro de oliveira"
+          }
+        ],
+        "date": "2024-07-31",
+        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+        "page": 2,
+        "title": "Elegy 3.5 truths",
+        "url": "https://miraclem.itch.io/elegy"
+      },
+      "name": "Santa Maria",
+      "truths": [
+        "truth:elegy/history",
+        "truth:elegy/origins",
+        "truth:elegy/superstitions",
+        "truth:elegy/genealogy",
+        "truth:elegy/what_mortals_know",
+        "truth:elegy/the_internet",
+        "truth:elegy/rebels",
+        "truth:elegy/blood_sorcery",
+        "truth:elegy/religion",
+        "truth:elegy/deviance",
+        "truth:elegy/werewolves",
+        "truth:elegy/elegies",
+        "truth:elegy/mortal_magic"
+      ],
+      "type": "world"
+    }
+  }
 }

--- a/generated-datasworn/manifest.json
+++ b/generated-datasworn/manifest.json
@@ -1,10 +1,10 @@
 {
-  "datasworn_version": "0.2.0",
+  "datasworn_version": "0.3.0",
   "packages": {
     "elegy": {
       "id": "elegy",
       "type": "ruleset",
-      "schemaLine": "0.2",
+      "schemaLine": "0.3",
       "packageName": "@datasworn-community/elegy",
       "path": "elegy.json",
       "description": "Datasworn JSON data for Elegy, a solo roleplaying game of vampires.",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "bun": ">=1.3"
   },
   "devDependencies": {
-    "@datasworn-community/build-tools": "0.2.10",
-    "@datasworn-community/core": "0.2.10",
-    "@datasworn-community/ironsworn-classic": "0.2.1",
-    "@datasworn-community/starforged": "0.2.1"
+    "@datasworn-community/build-tools": "0.3.0",
+    "@datasworn-community/core": "0.3.0",
+    "@datasworn-community/ironsworn-classic": "0.3.0",
+    "@datasworn-community/starforged": "0.3.0"
   }
 }

--- a/source_data/elegy/worlds.yaml
+++ b/source_data/elegy/worlds.yaml
@@ -1,0 +1,31 @@
+_id: elegy
+datasworn_version: "0.1.0"
+type: ruleset
+<<: &Source
+  title: 'Elegy 3.5 truths'
+  license: https://creativecommons.org/licenses/by-nc-sa/4.0
+  url: https://miraclem.itch.io/elegy
+  date: 2024-07-31
+  authors:
+    - name: moro de oliveira
+worlds:
+  santa_maria:
+    name: Santa Maria
+    type: world
+    _source:
+      <<: *Source
+      page: 2
+    truths:
+      - truth:elegy/history
+      - truth:elegy/origins
+      - truth:elegy/superstitions
+      - truth:elegy/genealogy
+      - truth:elegy/what_mortals_know
+      - truth:elegy/the_internet
+      - truth:elegy/rebels
+      - truth:elegy/blood_sorcery
+      - truth:elegy/religion
+      - truth:elegy/deviance
+      - truth:elegy/werewolves
+      - truth:elegy/elegies
+      - truth:elegy/mortal_magic


### PR DESCRIPTION
## Summary

- Upgrade Datasworn core/build-tools and official content dependencies to 0.3.0.
- Update schema/version configuration and authoring/publishing documentation.
- Add the Santa Maria world for Elegy and regenerate the tracked JSON/manifest outputs.

## Dependency note

The official 0.3.0 content packages are introduced by the accompanying official-content PR and are not on npm yet. This branch was built locally against the official-content 0.3.0 artifacts; install/CI should be rerun after those packages are published.

## Validation

- Local `bun run build` against official-content 0.3.0 artifacts.
- `bun run validate`.
- Verified Santa Maria has thirteen unique, resolvable truth references.