### PR TITLE
Align Elegy package with version 3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # Datasworn Elegy
 
 Datasworn source data and generated package artifacts for
-[Elegy](https://miraclem.itch.io/elegy), a solo roleplaying game of vampires by
+[Elegy 3.5](https://miraclem.itch.io/elegy), a solo roleplaying game of vampires by
 moro de oliveira.
 
-This repository builds the Elegy YAML source data into a publishable npm package
+This repository builds the Elegy 3.5 YAML source data into a publishable npm package
 with `@datasworn-community/build-tools`.
+
+The published package provides Datasworn JSON data for Elegy 3.5.
 
 ## Raw JSON
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,6 @@
       "devDependencies": {
         "@datasworn-community/build-tools": "0.3.0",
         "@datasworn-community/core": "0.3.0",
-        "@datasworn-community/ironsworn-classic": "0.3.0",
-        "@datasworn-community/starforged": "0.3.0",
       },
     },
   },
@@ -16,10 +14,6 @@
     "@datasworn-community/build-tools": ["@datasworn-community/build-tools@0.3.0", "", { "dependencies": { "@sinclair/typebox": "0.34.52", "ajv": "^8.20.0", "ajv-formats": "^3.0.1", "lodash-es": "^4.18.1", "yaml": "^2.9.0" }, "peerDependencies": { "@datasworn-community/core": "0.3.0" }, "bin": { "datasworn-build": "dist/cli/datasworn-build.js", "datasworn-migrate": "dist/cli/datasworn-migrate.js" } }, "sha512-01TYNOrw9jTSFL2AFh6ERXB7Y7yrBbRsTRoayF4CSBffvcOzxQdYwKogcdHkENTMLkPDzzuYtel2zpt4JtkXeQ=="],
 
     "@datasworn-community/core": ["@datasworn-community/core@0.3.0", "", {}, "sha512-z0MteE8eNROM44NInAt5RpXqa6gZm0ixs34ARsl+b2VkQI+BXy7OsTtTOeAtvggMi+xnvmME9F7IIqPh+aCFiA=="],
-
-    "@datasworn-community/ironsworn-classic": ["@datasworn-community/ironsworn-classic@0.3.0", "", { "dependencies": { "@datasworn-community/core": "^0.3.0" } }, "sha512-PDKgEkVHkV0oYtw6kBfbRVOSHnqLSOq1nC5ZiHYX9wilClSzxKqHifV5Ovu2TssMb/lgwmrKZm2HQvOcOSGUow=="],
-
-    "@datasworn-community/starforged": ["@datasworn-community/starforged@0.3.0", "", { "dependencies": { "@datasworn-community/core": "^0.3.0" } }, "sha512-sjdS3AkwO7wk8XMgU5KM28psjdgtShQO9r1BtalI8AOr/7u1wARzS6SERFSiIe9O2zcLr0JKEZM108dXFdeT3w=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.52", "", {}, "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw=="],
 

--- a/datasworn.config.yaml
+++ b/datasworn.config.yaml
@@ -10,16 +10,6 @@ packages:
     source: source_data/elegy
     packageName: "@datasworn-community/elegy"
     schemaLine: "0.3"
-    version: "0.3.0"
-    description: "Datasworn JSON data for Elegy, a solo roleplaying game of vampires."
+    version: "0.3.1"
+    description: "Datasworn JSON data for Elegy 3.5, a solo roleplaying game of vampires."
     license: "CC-BY-NC-SA-4.0"
-    dependencies:
-      - classic
-      - starforged
-    publishDependencies:
-      - id: classic
-        packageName: "@datasworn-community/ironsworn-classic"
-        schemaLine: "0.3"
-      - id: starforged
-        packageName: "@datasworn-community/starforged"
-        schemaLine: "0.3"

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -31,25 +31,14 @@ The package metadata lives in `datasworn.config.yaml`:
 Keep package IDs lowercase with underscores, such as `elegy`. Use npm package
 names with hyphens, such as `@datasworn-community/elegy`.
 
-## 3. Choose Dependencies
+## 3. Keep Elegy Self-Contained
 
-Elegy references IDs from both Ironsworn Classic and Starforged:
+Elegy 3.5 defines its own rules, moves, and oracles. All Datasworn references
+must resolve within the `elegy` package, so the package does not declare
+dependencies on Ironsworn Classic or Starforged.
 
-```yaml
-dependencies:
-  - classic
-  - starforged
-publishDependencies:
-  - id: classic
-    packageName: "@datasworn-community/ironsworn-classic"
-    schemaLine: "0.3"
-  - id: starforged
-    packageName: "@datasworn-community/starforged"
-    schemaLine: "0.3"
-```
-
-Keep both official packages in `devDependencies` so local builds can validate
-cross-package references.
+The validation script rejects external or unresolved Datasworn IDs and package
+dependency metadata.
 
 ## 4. Build and Validate
 

--- a/generated-datasworn/elegy.json
+++ b/generated-datasworn/elegy.json
@@ -12921,14 +12921,14 @@
             "shared": false
           },
           "sinner": {
-            "description": "Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood. If you spend more blood, you lose complete touch with your human side and turn into a beast.",
+            "description": "Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood and you spend more blood, you lose complete touch with your human side and turn into a beast.",
             "label": "sinner",
             "permanent": true,
             "prevents_recovery": [],
             "shared": false
           },
           "traumatized": {
-            "description": "Traumatized may be marked when you are Shaken, at 0 spirit, and suffer stress ([Endure Stress](datasworn:move:elegy/suffer/endure_stress)). Your experiences have left you emotionally or mentally scarred. When this impact is marked, you have 0 spirit and if you suffer more stress, your mind is forever lost.",
+            "description": "Traumatized may be marked when you are Shaken, at 0 spirit and suffers stress. Your experiences have left you emotionally or mentally scarred. When this impact is marked, you have 0 health and you suffer more stress, your mind is forever lost.",
             "label": "traumatized",
             "permanent": true,
             "prevents_recovery": [],

--- a/generated-datasworn/elegy.json
+++ b/generated-datasworn/elegy.json
@@ -4613,7 +4613,7 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/suffer/endure_stress.miss",
-              "text": "On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the list below."
+              "text": "On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the list below."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/suffer/endure_stress.strong_hit",
@@ -4625,7 +4625,7 @@
             }
           },
           "roll_type": "action_roll",
-          "text": "When you face mental shock or despair, suffer -spirit equal to your foe’s rank or as appropriate to the situation (see Stress). If your spirit is 0, suffer -focus equal to any remaining -spirit. Then, roll +Heart.\n\n- On a __strong hit__, choose one:\n  - Shake it off: If your spirit is greater than 0, suffer -1 focus in exchange for +1 spirit.\n  - Embrace the darkness: Take +1 focus.\n\n- On a __weak hit__, you press on.\n\n- On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the following table:\n\n{{table>move.oracle_rollable:elegy/suffer/endure_stress.endure_stress}}",
+          "text": "When you face mental shock or despair, suffer -spirit equal to your foe’s rank or as appropriate to the situation (see Stress). If your spirit is 0, suffer -focus equal to any remaining -spirit. Then, roll +Heart.\n\n- On a __strong hit__, choose one:\n  - Shake it off: If your spirit is greater than 0, suffer -1 focus in exchange for +1 spirit.\n  - Embrace the darkness: Take +1 focus.\n\n- On a __weak hit__, you press on.\n\n- On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the following table:\n\n{{table>move.oracle_rollable:elegy/suffer/endure_stress.endure_stress}}",
           "trigger": {
             "conditions": [
               {

--- a/generated-datasworn/elegy.json
+++ b/generated-datasworn/elegy.json
@@ -264,7 +264,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "You can find deep meaning within art. When you analyze a work of art, decide what to look for:\n  * Insight: Roll +intellect and add +1. On a hit, envision what helpful idea it revealed to you, and take +2 focus.\n  * Comfort: Roll +heart and add +1. On a hit, envision how the experience brought you comfort. Restore +3 spirit."
+              "text": "You can find deep meaning within art. When you analyze a work of art, choose your approach:\n  * Look for insight: Roll +intellect and add +1. On a hit, envision (or ask the oracle for) what helpful truth, concept or idea it revealed to you, and take +2 focus.\n  * Look for comfort: Roll +heart and add +1. On a hit, envision (or ask the oracle for) what comfort the experience brought to you, and restore +3 spirit."
             }
           ],
           "category": "Skill",
@@ -610,7 +610,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "Your vehicle provides speedy transport. When you drive fast or dangerously, add +1 and take +1 focus on a hit. On a strong hit with a match, take +1 focus."
+              "text": "You have a vehicle. When you drive fast or dangerously, add +1 and take +1 focus on a hit. On a strong hit with a match, take +1 focus."
             },
             {
               "_id": "asset.ability:elegy/asset/driver.1",
@@ -1182,7 +1182,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "When you meet a victim in the eyes, you may give it a simple command that will be obeyed instantly (“leave”, “follow”) unless it’s harmful to them or impossible (“die”, “fly”). The victim goes into a trance until right after the action, and won’t recall the incident."
+              "text": "When you meet a victim in the eyes, you may give it a simple command that will be obeyed instantly (“leave”, “follow”, “grab”) unless it’s harmful to them or impossible (“die”, “fly”). The victim goes into a trance until right after the action, and won’t recall the incident."
             },
             {
               "_id": "asset.ability:elegy/asset/hypnosis.1",
@@ -1347,13 +1347,74 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "When you conduct extended research or study, re-roll any dice. On a match, you piece together an extraordinary or harrowing new theory; envision the nature "
+              "text": "When you conduct extended research or study, re-roll any dice. On a match, you piece together an extraordinary or harrowing new theory; envision the nature of this revelation and take +1 forward if you act on it."
+            },
+            {
+              "_id": "asset.ability:elegy/asset/lore_keeper.2",
+              "controls": {},
+              "enabled": false,
+              "moves": {},
+              "options": {},
+              "oracles": {},
+              "text": "When you recall esoteric knowledge to your advantage, add +1. On a hit, envision the obscure but helpful fact, theory, or technique you put to use, and take +1 focus."
             }
           ],
           "category": "Skill",
           "controls": {},
           "count_as_impact": false,
           "name": "Lore Keeper",
+          "options": {},
+          "requirement": "None",
+          "shared": false,
+          "type": "asset"
+        },
+        "lunacy": {
+          "_id": "asset:elegy/asset/lunacy",
+          "_source": {
+            "authors": [
+              {
+                "name": "moro de oliveira"
+              }
+            ],
+            "date": "2024-07-31",
+            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 13,
+            "title": "Elegy 3.5",
+            "url": "https://miraclem.itch.io/elegy"
+          },
+          "abilities": [
+            {
+              "_id": "asset.ability:elegy/asset/lunacy.0",
+              "controls": {},
+              "enabled": true,
+              "moves": {},
+              "options": {},
+              "oracles": {},
+              "text": "You are able to heighten or dull someone’s current emotions (turn mild irritation into violent rage, or obsession into disinterest)."
+            },
+            {
+              "_id": "asset.ability:elegy/asset/lunacy.1",
+              "controls": {},
+              "enabled": false,
+              "moves": {},
+              "options": {},
+              "oracles": {},
+              "text": "You can disturb someone’s senses with flashes of content of their unconscious that will make them lose touch with reality for one minute."
+            },
+            {
+              "_id": "asset.ability:elegy/asset/lunacy.2",
+              "controls": {},
+              "enabled": false,
+              "moves": {},
+              "options": {},
+              "oracles": {},
+              "text": "You can make your victim mistake theirs or others’ identity. For example, you can make someone think they’re Napoleon, or think her wife is secretly an alien in disguise. This effect lasts for one scene."
+            }
+          ],
+          "category": "Power",
+          "controls": {},
+          "count_as_impact": false,
+          "name": "Lunacy",
           "options": {},
           "requirement": "None",
           "shared": false,
@@ -1442,7 +1503,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "Your mannequin trusts you way more than they should. When you gather info about the mortal world from your mannequin, you may re-roll any dice."
+              "text": "Your mannequin trusts you way more than they should. When you gather info about the mortal world by speaking to your mannequin, you may re-roll any dice."
             },
             {
               "_id": "asset.ability:elegy/asset/mannequin.2",
@@ -1754,7 +1815,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "When you possess more than one point of this asset, you can choose to repel only certain types of creatures. For instance, even with points 1 and 2, you can opt to repel only supernatural living creatures if desired."
+              "text": "When you draw a circle in blood and chant magic words, the area will magically repel supernatural living creatures."
             },
             {
               "_id": "asset.ability:elegy/asset/path_of_the_guardian.2",
@@ -1763,12 +1824,13 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "You can repel vampires and the undead."
+              "text": "When you draw a circle in blood and chant magic words, the area will magically repel vampires and the undead."
             }
           ],
           "category": "Ritual",
           "controls": {},
           "count_as_impact": false,
+          "description": "If you possess more than one point of this asset, you can choose to repel only certain types of creatures. For instance, even with points 1 and 2, you can opt to repel only supernatural living creatures if desired.",
           "name": "Path of the Guardian",
           "options": {},
           "requirement": "None",
@@ -1849,7 +1911,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "When you wash your face in blood and speak the name of a victim, she will experience intense hunger. A vampire will be induced to starvation, and will act out of hunger."
+              "text": "When you wash your face in blood and speak the name of a victim, she will experience intense hunger. A vampire will be induced to starvation, and will act out of instinct, impulse and hunger."
             },
             {
               "_id": "asset.ability:elegy/asset/path_of_the_spider.1",
@@ -1867,7 +1929,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "This ceremony is only potent against living entities. By burning a strand of hair, or any other refuse from the subject’s body, and uttering mystical incantations, a curse is placed that you can activate at will. When you do, the victim’s throat splits, and their bowels forcefully expel from their body, leading to almost certain death, even with immediate medical intervention."
+              "text": "This ceremony is only potent against living entities. By burning a strand of hair, a nail clipping, or any other refuse from the subject’s body, and uttering mystical incantations, a curse is placed that you can activate at will. When you do, the victim’s throat splits, and their bowels forcefully expel from their body, leading to almost certain death, even with immediate medical intervention."
             }
           ],
           "category": "Ritual",
@@ -2213,7 +2275,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "You can sense the intentions of people around you. When you are next to other individuals, you can awaken your powers to ask two of the following questions to the oracle. Then, add +1 and take +1 focus the next move related to the answer.\n- Who's the most susceptible person in here?\n- Who's most likely to harm me?\n- Who's most likely to give me what I want?"
+              "text": "You can sense the intentions of people around you. When you are next to other individuals, you can awaken your powers to ask two of the following questions to the oracle. Then, add +1 and take +1 focus the next move related to the answer.\n- Who's the weakest person in here?\n- Who's most likely to harm me?\n- Who's most likely to give me what I want?"
             },
             {
               "_id": "asset.ability:elegy/asset/sixth_sense.1",
@@ -2222,7 +2284,16 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "You can read people’s thoughts and memories. Once per night, you may psychically inspect the mind of someone next to you as if it were a book. When you hold an object in your hands, you are able to pick up psychic impressions from it and learn who held it last and when it was last held."
+              "text": "You can read people’s thoughts and memories. Once per night, you may psychically inspect the mind of someone next to you as if it were a book."
+            },
+            {
+              "_id": "asset.ability:elegy/asset/sixth_sense.2",
+              "controls": {},
+              "enabled": false,
+              "moves": {},
+              "options": {},
+              "oracles": {},
+              "text": "When you hold an object in your hands, you are able to pick up psychic impressions from it and learn who held it last and when it was last held."
             }
           ],
           "category": "Power",
@@ -2473,7 +2544,7 @@
               "moves": {},
               "options": {},
               "oracles": {},
-              "text": "In some ways, time brought you closer to the mortals around you. Whenever you communicate with or read the emotions of humans, add +1 and take +1 focus on a hit."
+              "text": "In some ways, time brought you even closer to your late humanity and to the mortals around you. Whenever you communicate with or read the emotions of humans, add +1 and take +1 focus on a hit."
             },
             {
               "_id": "asset.ability:elegy/asset/weak_blood.2",
@@ -2599,7 +2670,7 @@
           "type": "asset"
         }
       },
-      "description": "__Assets__ represent your abilities, background,skills, traits, and resources. When you create your character, you pick three assets.",
+      "description": "__Assets__ represent your abilities, background, skills, traits, and resources. When you create your character, you pick three assets.",
       "name": "Elegy Assets",
       "type": "asset_collection"
     }
@@ -2641,7 +2712,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 6,
+            "page": 5,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -2667,7 +2738,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 4,
+            "page": 3,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -2676,10 +2747,10 @@
           "oracles": {},
           "outcomes": null,
           "roll_type": "no_roll",
-          "text": "When you Secure an Advantage in direct support of an ally and score a hit, they (instead of you) can take the benefits of the move. If you are in combat and score a strong hit, you and your ally have initiative.",
+          "text": "When you [Secure an Advantage](datasworn:move:elegy/adventure/secure_an_advantage) in direct support of an ally and score a hit, they (instead of you) can take the benefits of the move. If you are in combat and score a strong hit, you and your ally have initiative.",
           "trigger": {
             "conditions": [],
-            "text": "When you Secure an Advantage in direct support of an ally..."
+            "text": "When you [Secure an Advantage](datasworn:move:elegy/adventure/secure_an_advantage) in direct support of an ally..."
           },
           "type": "move"
         },
@@ -2693,8 +2764,8 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 107,
-            "title": "Elegy 3.5 Moves",
+            "page": 42,
+            "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
           "allow_momentum_burn": false,
@@ -2860,7 +2931,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 5,
+            "page": 3,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -2943,7 +3014,7 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/adventure/face_danger.miss",
-              "text": "On a __miss__, you fail or suffer a dire consequence. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
+              "text": "On a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/adventure/face_danger.strong_hit",
@@ -2951,11 +3022,11 @@
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/adventure/face_danger.weak_hit",
-              "text": "On a __weak hit__, you succeed but at a cost. Take +1 focus and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
+              "text": "On a __weak hit__, you succeed, but not without a cost. Take +1 focus and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             }
           },
           "roll_type": "action_roll",
-          "text": "When you attempt something risky or react to an imminent threat, envision your action and roll. If you act...\n  - With stealth, speed, or coordination: Roll +dexterity.\n  - With courage, willpower, or empathy: Roll +heart.\n  - With aggression, strength, or toughness: Roll +force.\n  - With charm, composure, or manipulation: Roll +glamour.\n  - With expertise, focus, or observation: Roll +intellect.\nOn a __strong hit__, you are successful. Take +1 focus.\nOn a __weak hit__, you succeed but at a cost. Take +1 focus and  [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\nOn a __miss__, you fail or suffer a dire consequence. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
+          "text": "When you attempt something risky or react to an imminent threat, envision your action and roll. If you act...\n  - With stealth, speed, or coordination: Roll +dexterity.\n  - With courage, willpower, or empathy: Roll +heart.\n  - With aggression, strength, or toughness: Roll +force.\n  - With charm, composure, or manipulation: Roll +glamour.\n  - With expertise, focus, or observation: Roll +intellect.\nOn a __strong hit__, you are successful. Take +1 focus.\nOn a __weak hit__, you succeed, but not without a cost. Take +1 focus and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\nOn a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "trigger": {
             "conditions": [
               {
@@ -3028,7 +3099,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 9,
+            "page": 5,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3112,7 +3183,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 4,
+            "page": 3,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3122,19 +3193,19 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/adventure/gather_information.miss",
-              "text": "On a __miss__, you unearth a dire threat or unwelcome truth. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
+              "text": "On a __miss__, your investigation unearths a dire threat or reveals an unwelcome truth that undermines your quest. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/adventure/gather_information.strong_hit",
-              "text": "On a __strong hit__, You discover something helpful and specific. Take +2 focus."
+              "text": "On a __strong hit__, you discover something helpful and specific. The path you must follow or action you must take to make progress is made clear. Envision what you learn. Then, take +2 focus."
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/adventure/gather_information.weak_hit",
-              "text": "On a __weak hit__, You discover something that complicates your quest or introduces danger. Take +1 focus."
+              "text": "On a __weak hit__, the information provides new insight, but also complicates your quest. Envision what you discover. Then, take +1 focus."
             }
           },
           "roll_type": "action_roll",
-          "text": "When you search for clues, conduct an investigation, or analyze evidence, roll +intellect. If you act within a community or ask questions of someone you share a bond with, add +1.\nOn a __strong hit__, you discover something helpful and specific. Envision what you learn, and take +2 focus.\nOn a __weak hit__, you discover something that complicates your quest or introduces new danger. Take +1 focus.\nOn a __miss__, you unearth a dire threat or an unwelcome truth that undermines your quest. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
+          "text": "When you search for clues, conduct an investigation, analyze evidence, or do research, roll +intellect.\nOn a __strong hit__, you discover something helpful and specific. The path you must follow or action you must take to make progress is made clear. Envision what you learn. Then, take +2 focus.\nOn a __weak hit__, the information provides new insight, but also complicates your quest. Envision what you discover. Then, take +1 focus.\nOn a __miss__, your investigation unearths a dire threat or reveals an unwelcome truth that undermines your quest. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "trigger": {
             "conditions": [
               {
@@ -3148,7 +3219,7 @@
                 ]
               }
             ],
-            "text": "When you search for clues, conduct an investigation, or analyze evidence..."
+            "text": "When you search for clues, conduct an investigation, analyze evidence, or do research..."
           },
           "type": "move"
         },
@@ -3162,7 +3233,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 7,
+            "page": 5,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3195,8 +3266,7 @@
                     "stat": "force",
                     "using": "stat"
                   }
-                ],
-                "text": "With your supernatural abilities to heal"
+                ]
               }
             ],
             "text": "When you spend a few seconds in place and use your supernatural abilities to heal yourself..."
@@ -3213,7 +3283,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 6,
+            "page": 4,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3289,7 +3359,7 @@
             }
           },
           "roll_type": "action_roll",
-          "text": "When you perform a ritual of blood magic, envision what you want to achieve and how you perform it. Then, roll +Intellect.\n- On a __strong hit__, the ritual is performed successfully. Take +1 focus.\n- On a __weak hit__, the ritual is performed successfully, but it consumes the blood within you. Spend 1 blood.\n- On a __miss__, the ritual consumes your blood and has undesired consequences. Spend 1 blood and roll: \\n {{table>move.oracle_rollable:elegy/adventure/perform_ritual.perform_ritual}}\n  - 1-20: The ritual has the opposite effect.\n  - 21-40: It attracts mortal attention.\n  - 41-60: It affects a different target.\n  - 61-80: It has no effect, and you waste or lose resources needed to perform it again.\n  - 81-00: It has no effect, and it consumes you: lose 2 points of blood, health, or spirit (pick 1).",
+          "text": "To decide if you want to include rituals in your setting, see the Rituals Truths.\n\nWhen you perform a ritual of blood magic, envision what you want to achieve and how you perform it. Then, roll +Intellect.\n- On a __strong hit__, the ritual is performed successfully. Take +1 focus.\n- On a __weak hit__, the ritual is performed successfully, but it consumes the blood within you. Spend 1 blood.\n- On a __miss__, the ritual consumes your blood and has undesired consequences. Spend 1 blood and roll on the list below:\n\n  {{table>move.oracle_rollable:elegy/adventure/perform_ritual.perform_ritual}}\n  - 1-20: The ritual has the opposite effect.\n  - 21-40: It attracts mortal attention.\n  - 41-60: It affects a different target.\n  - 61-80: It has no effect, and you waste or lose resources needed to perform it again.\n  - 81-00: It has no effect, and it consumes you: lose 2 points of blood, health, or spirit (pick 1).",
           "trigger": {
             "conditions": [
               {
@@ -3317,6 +3387,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 5,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3337,7 +3408,6 @@
               "text": "On a __weak hit__, this indulgence is fleeting. Envision an interruption, complication, or inner conflict, and lose 1 focus."
             }
           },
-          "page": 5,
           "roll_type": "action_roll",
           "text": "When you socialize, share intimacy, or find a moment of peace, roll +heart.\n- On a __strong hit__, you find companionship or comfort and your spirit is strengthened. If you are shaken, clear the impact and take +1 spirit. Otherwise, take +2 spirit.\n- On a __weak hit__, as above, but this indulgence is fleeting. Envision an interruption, complication, or inner conflict. Then, lose 1 focus.\n- On a __miss__, you take no comfort and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "trigger": {
@@ -3368,7 +3438,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 6,
+            "page": 4,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3378,7 +3448,7 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/adventure/rest.miss",
-              "text": "On a __miss__, you pick one of the following: You get hungrier and lose 1 blood, or you don't sleep well and lose 1 focus."
+              "text": "On a __miss__, pick one of the options below. On a match, pick both: You get hungrier and lose 1 blood, or you don't sleep well and lose 1 focus."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/adventure/rest.strong_hit",
@@ -3390,7 +3460,7 @@
             }
           },
           "roll_type": "action_roll",
-          "text": "When you spend the whole daytime in deep sleep in a dark place, roll +heart or +intellect, whichever is higher. By default, you need the Lair asset to have access to a secure place to sleep you can call yours. If you don’t have it, you must sleep in abandoned places.\nOn a __strong hit__, you rest well, and gain both of the following benefits:\n- Restore 1 health\n- Gain +2 focus\nOn a __weak hit__, you rest with only partial success. You gain only one of the benefits:\n- Restore 1 health or Gain +2 focus.\nOn a __miss__, choose one of the following:\n- You get hungrier: Lose 1 blood\n- You don't sleep well: Lose 1 focus",
+          "text": "When you spend the whole daytime in deep sleep in a dark place, roll +heart or +intellect, whichever is higher. By default, you need the Lair asset to have access to a secure place to sleep you can call yours. If you don’t have it, you must sleep in abandoned places.\nOn a __strong hit__, you rest well, and gain both of the following benefits:\n- Restore 1 health\n- Gain +2 focus\nOn a __weak hit__, you rest with only partial success. You gain only one of the benefits:\n- Restore 1 health or Gain +2 focus.\nOn a __miss__, pick one of the options below. On a match, pick both:\n- You get hungrier: Lose 1 blood\n- You don't sleep well: Lose 1 focus",
           "trigger": {
             "conditions": [
               {
@@ -3437,15 +3507,15 @@
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/adventure/secure_an_advantage.strong_hit",
-              "text": "On a __strong hit__, Take both benefits: +2 focus and +1 on your next roll."
+              "text": "On a hit, you succeed. On a __strong hit__, take both benefits:\n- Take +2 focus.\n- Add +1 on your next roll (not a Conclusion move)."
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/adventure/secure_an_advantage.weak_hit",
-              "text": "On a __weak hit__, Take one benefit: +2 focus or +1 on your next roll."
+              "text": "On a __weak hit__, choose one:\n- Take +2 focus.\n- Add +1 on your next roll (not a Conclusion move)."
             }
           },
           "roll_type": "action_roll",
-          "text": "When you assess a situation, make preparations, or attempt to gain leverage, envision your action and roll. If you act...\n  - With stealth, speed, or coordination: Roll +dexterity.\n  - With courage, willpower, or empathy: Roll +heart.\n  - With aggression, strength, or toughness: Roll +force.\n  - With charm, composure, or manipulation: Roll +glamour.\n  - With expertise, focus, or observation: Roll +intellect.\nOn a __strong hit__, take both benefits:\n  - Take +2 focus.\n  - Add +1 on your next roll (not a Conclusion move).\nOn a __weak hit__, take one benefit:\n  - Take +2 focus or add +1 on your next roll.\nOn a __miss__, you fail or your assumptions betray you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
+          "text": "When you assess a situation, make preparations, or attempt to gain leverage, envision your action and roll. If you act...\n  - With stealth, speed, or coordination: Roll +dexterity.\n  - With courage, willpower, or empathy: Roll +heart.\n  - With aggression, strength, or toughness: Roll +force.\n  - With charm, composure, or manipulation: Roll +glamour.\n  - With expertise, focus, or observation: Roll +intellect.\nOn a hit, you succeed. On a __strong hit__, take both benefits:\n  - Take +2 focus.\n  - Add +1 on your next roll (not a Conclusion move).\nOn a __weak hit__, take one benefit:\n  - Take +2 focus or add +1 on your next roll.\nOn a __miss__, you fail or your assumptions betray you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "trigger": {
             "conditions": [
               {
@@ -3518,7 +3588,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 5,
+            "page": 4,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3655,11 +3725,11 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/combat/battle.miss",
-              "text": "On a __miss__, you are defeated and the objective is lost to you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
+              "text": "On a __miss__, you are defeated or the objective is lost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/combat/battle.strong_hit",
-              "text": "On a __strong hit__, you achieve your objective unconditionally. Take +2 momentum."
+              "text": "On a __strong hit__, you achieve your objective unconditionally. You and any allies who joined the battle may take +2 focus."
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/combat/battle.weak_hit",
@@ -3667,7 +3737,7 @@
             }
           },
           "roll_type": "action_roll",
-          "text": "When __you fight a battle, and it happens in a blur__, envision your objective and roll. If you primarily...\n\n  * Fight at range, or using your speed and the terrain to your advantage: Roll +dexterity.\n  * Fight depending on your courage, allies, or companions: Roll +heart.\n  * Fight in close to overpower your opponents: Roll +force.\n  * Fight using trickery to befuddle your opponents: Roll +dexterity.\n  * Fight using careful tactics to outsmart your opponents: Roll +intellect.\n\nOn a __strong hit__, you achieve your objective unconditionally. Take +2 momentum.\n\nOn a __weak hit__, you achieve your objective, but not without cost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\n\nOn a __miss__, you are defeated and the objective is lost to you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
+          "text": "When __you fight a battle, and it happens in a blur__, envision your objective and roll. If you primarily...\n\n  * Fight at range or using your speed or trickery to your advantage: Roll +dexterity.\n  * Fight depending on your courage, leadership, or companions: Roll +heart.\n  * Fight in close to overpower your foe: Roll +force.\n  * Fight using careful tactics to outsmart your foe: Roll +intellect.\n\nOn a __strong hit__, you achieve your objective unconditionally. You and any allies who joined the battle may take +2 focus.\n\nOn a __weak hit__, you achieve your objective, but not without cost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\n\nOn a __miss__, you are defeated or the objective is lost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "trigger": {
             "conditions": [
               {
@@ -3679,7 +3749,7 @@
                     "using": "stat"
                   }
                 ],
-                "text": "Fight at range, or using your speed and the terrain to your advantage"
+                "text": "Fight at range or using your speed or trickery to your advantage"
               },
               {
                 "_id": "move.condition:elegy/combat/battle.1",
@@ -3690,7 +3760,7 @@
                     "using": "stat"
                   }
                 ],
-                "text": "Fight depending on your courage, allies, or companions"
+                "text": "Fight depending on your courage, leadership, or companions"
               },
               {
                 "_id": "move.condition:elegy/combat/battle.2",
@@ -3701,21 +3771,10 @@
                     "using": "stat"
                   }
                 ],
-                "text": "Fight in close to overpower your opponents"
+                "text": "Fight in close to overpower your foe"
               },
               {
                 "_id": "move.condition:elegy/combat/battle.3",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "stat": "dexterity",
-                    "using": "stat"
-                  }
-                ],
-                "text": "Fight using trickery to befuddle your opponents"
-              },
-              {
-                "_id": "move.condition:elegy/combat/battle.4",
                 "method": "player_choice",
                 "roll_options": [
                   {
@@ -3723,10 +3782,10 @@
                     "using": "stat"
                   }
                 ],
-                "text": "Fight using careful tactics to outsmart your opponents"
+                "text": "Fight using careful tactics to outsmart your foe"
               }
             ],
-            "text": "When you fight a battle, and it happens in a blur, and you..."
+            "text": "When you fight a battle, and it happens in a blur..."
           },
           "type": "move"
         },
@@ -3750,7 +3809,7 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/combat/clash.miss",
-              "text": "On a __miss__, your foe dominates this exchange. Pay the Price."
+              "text": "On a __miss__, your foe dominates this exchange. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/combat/clash.strong_hit",
@@ -3758,11 +3817,11 @@
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/combat/clash.weak_hit",
-              "text": "On a __weak hit__, mark progress, but you are dealt a counterblow or setback. Pay the Price."
+              "text": "On a __weak hit__, mark progress, but you are dealt a counterblow or setback. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             }
           },
           "roll_type": "action_roll",
-          "text": "__When you fight against a foe at close quarters or exchange fire at a distance__, roll +Force if you are in close combat, or roll +Dexterity if you are exchanging fire.\n\n- On a __strong hit__, mark progress twice. You overwhelm your foe.\n- On a __weak hit__, mark progress, but you are dealt a counterblow or setback. Pay the Price.\n- On a __miss__, your foe dominates this exchange. Pay the Price.",
+          "text": "__When you fight against a foe at close quarters or exchange fire at a distance__, roll +Force if you are in close combat, or roll +Dexterity if you are exchanging fire.\n\n- On a __strong hit__, mark progress twice. You overwhelm your foe.\n- On a __weak hit__, mark progress, but you are dealt a counterblow or setback. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\n- On a __miss__, your foe dominates this exchange. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "trigger": {
             "conditions": [
               {
@@ -3804,11 +3863,11 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/combat/end_the_fight.miss",
-              "text": "On a __miss__, you have lost this fight. [Pay the Price](datasworn:move:starforged/fate/pay_the_price)."
+              "text": "On a __miss__, you have lost this fight. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/combat/end_the_fight.strong_hit",
-              "text": "On a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent."
+              "text": "On a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure)."
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/combat/end_the_fight.weak_hit",
@@ -3816,7 +3875,7 @@
             }
           },
           "roll_type": "progress_roll",
-          "text": "__When you take decisive action to end the fight__, roll the challenge dice and compare to your progress. Focus is ignored on this roll.\n\nOn a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent.\n\nOn a __weak hit__, as above, but you must also choose one:\n  * It’s worse than you thought: [Endure Harm](datasworn:move:starforged/suffer/endure_harm).\n  * You are overcome: [Endure Stress](datasworn:move:starforged/suffer/endure_stress).\n  * Your victory is short-lived: A new danger or foe appears, or an existing danger worsens.\n  * You suffer collateral damage: Something of value is lost or broken, or someone important must pay the cost.\n  * You’ll pay for it: An objective falls out of reach.\n  * Others won’t forget: You are marked for vengeance.\n\nOn a __miss__, you have lost this fight. [Pay the Price](datasworn:move:starforged/fate/pay_the_price).",
+          "text": "__Conclusion move.__ When you take decisive action, roll the challenge dice and compare to your progress. Focus is ignored on this roll.\n\nOn a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure).\n\nOn a __weak hit__, as above, but you must also choose one:\n  * It’s worse than you thought: [Endure Harm](datasworn:move:elegy/suffer/endure_harm).\n  * You are overcome: [Endure Stress](datasworn:move:elegy/suffer/endure_stress).\n  * Your victory is short-lived: A new danger or foe appears, or an existing danger worsens.\n  * You suffer collateral damage: Something of value is lost or broken, or someone important must pay the cost.\n  * You’ll pay for it: An objective falls out of reach.\n  * Others won’t forget: You are marked for vengeance.\n\nOn a __miss__, you have lost this fight. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "tracks": {
             "category": "Combat",
             "controls": {}
@@ -3833,7 +3892,7 @@
                 ]
               }
             ],
-            "text": "When you take decisive action to end the fight..."
+            "text": "When you take decisive action..."
           },
           "type": "move"
         },
@@ -3914,7 +3973,7 @@
         ],
         "date": "2024-07-31",
         "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-        "page": 11,
+        "page": 9,
         "title": "Elegy 3.5 Moves",
         "url": "https://miraclem.itch.io/elegy"
       },
@@ -3930,7 +3989,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 10,
+            "page": 9,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3939,7 +3998,7 @@
           "oracles": {},
           "outcomes": null,
           "roll_type": "no_roll",
-          "text": "When a relationship with a connection is reinforced by...\n- accomplishing a mission that benefits them\n- seeking their assistance during dire situations\n- presenting them with a valuable gift\n- sharing a significant moment\n- standing by them in times of hardship\n- successfully navigating a test of your relationship\n...mark progress according to the rank of the connection.",
+          "text": "When a relationship with a connection is reinforced by...\n- accomplishing a mission that benefits them\n- seeking their assistance during dire situations\n- presenting them with a valuable gift\n- sharing a significant moment\n- standing by them in times of hardship\n- successfully navigating a [Test Your Relationship](datasworn:move:elegy/connection/test_your_relationship)\n...mark progress according to the rank of the connection.",
           "trigger": {
             "conditions": [],
             "text": "When a relationship with a connection is reinforced by..."
@@ -3956,7 +4015,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 12,
+            "page": 10,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -3966,19 +4025,19 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/connection/form_a_bond.miss",
-              "text": "On a __miss__, the connection reveals a motivation or background that introduces tension. If you wish to continue the relationship, roll both challenge dice, take the lower value, and clear that number of progress boxes. Then, increase the connection’s rank by one (if not already epic)."
+              "text": "On a __miss__, they reveal a motivation or background that introduces tension. If you decide to maintain this relationship, roll both challenge dice, take the lower value, and clear that number of progress boxes. Then, increase the connection’s rank by one (if not already epic)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/connection/form_a_bond.strong_hit",
-              "text": "On a __strong hit__, a bond is established. Earn XP based on the connection's rank. This reward extends to all allies tied to this connection. When bonded allies support you in a move related to their role, add +2 instead of +1, and take +1 focus."
+              "text": "On a __strong hit__, a bond is established. Earn XP based on the connection’s rank:\n- Troublesome = 1 tick\n- Dangerous = 2 ticks\n- Formidable = 1 box\n- Extreme = 2 boxes\n- Epic = 3 boxes\n\nThis reward extends to all allies tied to this connection. When a character you’re bonded to supports you in a move closely related to their role, add +2 instead of +1, and take +1 focus."
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/connection/form_a_bond.weak_hit",
-              "text": "On a __weak hit__, follow the same steps as above, but your connection seeks something more first. Envision what they request and fulfill it, or Sing an Elegy to guarantee its completion."
+              "text": "On a __weak hit__, follow the same steps as above, but your connection seeks something more first. To form the bond and earn the XP reward, envision the request and fulfill it (or [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to guarantee its completion)."
             }
           },
           "roll_type": "progress_roll",
-          "text": "When your connection with someone is ready to evolve, roll the challenge dice and compare the result with your progress.\n\n- On a __strong hit__, a bond is established. Earn XP based on the connection’s rank:\n  - Troublesome = 1 tick\n  - Dangerous = 2 ticks\n  - Formidable = 1 box\n  - Extreme = 2 boxes\n  - Epic = 3 boxes\n\n  This reward extends to all allies tied to this connection. When a character you’re bonded to supports you in a move closely related to their role, add +2 instead of +1, and take +1 focus.\n\n- On a __weak hit__, follow the same steps as above, but your connection seeks something more first. To form the bond and earn the XP reward, envision the request and fulfill it (or Sing an Elegy to guarantee its completion).\n\n- On a __miss__, they reveal a motivation or background that introduces tension. If you decide to maintain this relationship, roll both challenge dice, take the lower value, and clear that number of progress boxes. Then, increase the connection’s rank by one (if not already epic).",
+          "text": "Conclusion move. When your connection with someone is ready to evolve, roll the challenge dice and compare the result with your progress.\n\n- On a __strong hit__, a bond is established. Earn XP based on the connection’s rank:\n  - Troublesome = 1 tick\n  - Dangerous = 2 ticks\n  - Formidable = 1 box\n  - Extreme = 2 boxes\n  - Epic = 3 boxes\n\n  This reward extends to all allies tied to this connection. When a character you’re bonded to supports you in a move closely related to their role, add +2 instead of +1, and take +1 focus.\n\n- On a __weak hit__, follow the same steps as above, but your connection seeks something more first. To form the bond and earn the XP reward, envision the request and fulfill it (or [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to guarantee its completion).\n\n- On a __miss__, they reveal a motivation or background that introduces tension. If you decide to maintain this relationship, roll both challenge dice, take the lower value, and clear that number of progress boxes. Then, increase the connection’s rank by one (if not already epic).",
           "tracks": {
             "category": "Connection",
             "controls": {}
@@ -4009,7 +4068,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 10,
+            "page": 9,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4019,7 +4078,7 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/connection/make_connection.miss",
-              "text": "On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).."
+              "text": "On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/connection/make_connection.strong_hit",
@@ -4031,7 +4090,7 @@
             }
           },
           "roll_type": "action_roll",
-          "text": "When you search out a new relationship or give focus to an existing relationship (not an ally or companion), roll +Heart.\n\n- On a __strong hit__, you create a connection. Give them a role and rank. Whenever your connection aids you on a move closely associated with their role, add +1 and take +1 focus on a hit.\n\n- On a __weak hit__, as above, but this connection comes with a complication or cost. Envision what they reveal or demand.\n\n- On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)..",
+          "text": "When you search out a new relationship or give focus to an existing relationship (not an ally or companion), roll +Heart.\n\n- On a __strong hit__, you create a connection. Give them a role and rank. Whenever your connection aids you on a move closely associated with their role, add +1 and take +1 focus on a hit.\n\n- On a __weak hit__, as above, but this connection comes with a complication or cost. Envision what they reveal or demand.\n\n- On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).",
           "trigger": {
             "conditions": [
               {
@@ -4059,7 +4118,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 11,
+            "page": 9,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4069,19 +4128,19 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/connection/test_your_relationship.miss",
-              "text": "On a __miss__, or if you have no interest in maintaining the relationship, choose one: \n - Lose the connection: Envision how this impacts you and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price). \n - Prove your loyalty: Envision what you offer or what they demand, and Sing an Elegy (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone."
+              "text": "On a __miss__, or if you have no interest in maintaining this relationship, choose one:\n- Lose the connection: Envision how this impacts you and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\n- Prove your loyalty: Envision what you offer or what they demand, and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/connection/test_your_relationship.strong_hit",
-              "text": "On a __strong hit__, mark progress. Your bond is strengthened, and the relationship endures."
+              "text": "On a __strong hit__, mark progress."
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/connection/test_your_relationship.weak_hit",
-              "text": "On a __weak hit__, mark progress, but envision a complication or demand that arises as a result of this test. The relationship is strained or has a cost."
+              "text": "On a __weak hit__, mark progress, but also envision a demand or complication as a fallout of this test."
             }
           },
           "roll_type": "action_roll",
-          "text": "When your relationship with a connection is tested through conflict, betrayal, or circumstance, roll +Heart. If you share a bond, add +1.\n\n- On a __strong hit__, mark progress.\n- On a __weak hit__, mark progress, but also envision a demand or complication as a fallout of this test.\n- On a __miss__, or if you have no interest in maintaining this relationship, choose one:\n  - Lose the connection: Envision how this impacts you and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\n  - Prove your loyalty: Envision what you offer or what they demand, and Sing an Elegy (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone.",
+          "text": "When your relationship with a connection is tested through conflict, betrayal, or circumstance, roll +Heart. If you share a bond, add +1.\n\n- On a __strong hit__, mark progress.\n- On a __weak hit__, mark progress, but also envision a demand or complication as a fallout of this test.\n- On a __miss__, or if you have no interest in maintaining this relationship, choose one:\n  - Lose the connection: Envision how this impacts you and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).\n  - Prove your loyalty: Envision what you offer or what they demand, and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone.",
           "trigger": {
             "conditions": [
               {
@@ -4114,7 +4173,7 @@
         ],
         "date": "2024-07-31",
         "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-        "page": 11,
+        "page": 6,
         "title": "Elegy 3.5 Moves",
         "url": "https://miraclem.itch.io/elegy"
       },
@@ -4130,7 +4189,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 160,
+            "page": 7,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4139,7 +4198,7 @@
           "oracles": {},
           "outcomes": null,
           "roll_type": "no_roll",
-          "text": "__When you renounce your quest, betray your promise, or the goal is lost to you__, clear the elegy.\n\nThen, envision the impact of this failure and choose one or more as appropriate to the nature of the elegy. Any allies who shared this vow may also envision a cost.\n\n  * You are demoralized or dispirited: [Endure Stress](datasworn:move:elegy/suffer/endure_stress).\n  * A connection loses faith: [Test Your Relationship](datasworn:move:elegy/connection/test_your_relationship) when you next interact.\n  * Your supernatural abilities weaken drastically: Discard a power asset.\n  * You must abandon a path or resource: Discard an asset (not a power or nature one).\n  * Someone else pays a price: Envision how a person, being, or community bears the cost of the failure.\n  * Someone else takes advantage: Envision how an enemy gains power.\n  * Your reputation suffers: Envision how this failure marks you.",
+          "text": "__When you renounce your quest, betray your promise, or the goal is lost to you__, clear the elegy.\n\nThen, envision the impact of this failure and choose one or more as appropriate to the nature of the elegy. Any allies who shared this vow may also envision a cost.\n\n  * You are demoralized or dispirited: Lose spirit according to the situation (see Stress).\n  * A connection loses faith: [Test Your Relationship](datasworn:move:elegy/connection/test_your_relationship) when you next interact.\n  * Your supernatural abilities weaken drastically: Discard a power asset.\n  * You must abandon a path or resource: Discard an asset (not a power or nature one).\n  * Someone else pays a price: Envision how a person, being, or community bears the cost of the failure.\n  * Someone else takes advantage: Envision how an enemy gains power.\n  * Your reputation suffers: Envision how this failure marks you.",
           "trigger": {
             "conditions": [],
             "text": "When you renounce your quest, betray your promise, or the goal is lost to you..."
@@ -4156,7 +4215,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 17,
+            "page": 6,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4166,19 +4225,19 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/quest/fulfill_your_elegy.miss",
-              "text": "On a __miss__, your quest is undone through an unexpected complication or realization. Envision what happens and choose one:\n  * Give up on the quest: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy).\n  * Recommit to the quest: Roll both challenge dice, take the lowest value, and clear that number of progress boxes. Then, raise the quest's rank by one (if not already epic)."
+              "text": "On a __miss__, your quest is undone. Envision what happens ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and choose one:\n  * You recommit: Clear all but one filled progress, and raise the quest’s rank by one (if not already epic).\n  * You give up: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy)."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/quest/fulfill_your_elegy.strong_hit",
-              "text": "On a __strong hit__, your quest is complete. Mark a reward on your quest's legacy track per the quest's rank:\n  - Troublesome: 1 tick\n  - Dangerous: 2 ticks\n  - Formidable: 1 box\n  - Extreme: 2 boxes\n  - Epic: 3 boxes.\nAny allies who shared this vow also mark the reward."
+              "text": "On a __strong hit__, your quest is complete. Mark experience (troublesome=1; dangerous=2; formidable=3; extreme=4; epic=5)."
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/quest/fulfill_your_elegy.weak_hit",
-              "text": "On a __weak hit__, your quest is fulfilled, but there is more to be done or you realize the truth of your quest. If you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right, take your full legacy reward per the quest's rank. Otherwise, make the reward one rank lower. Any allies who shared this vow also mark the reward."
+              "text": "On a __weak hit__, there is more to be done, or you realize the truth of your quest. Envision what you discover ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure). Then, mark experience (troublesome=0; dangerous=1; formidable=2; extreme=3; epic=4). You may [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right. If you do, add +1."
             }
           },
           "roll_type": "progress_roll",
-          "text": "__When you achieve what you believe to be the fulfillment of your promise__, roll the challenge dice and compare to your progress.\n\nOn a __strong hit__, your quest is complete. Mark a reward on your quest's legacy track per the quest's rank:\n  - Troublesome: 1 tick\n  - Dangerous: 2 ticks\n  - Formidable: 1 box\n  - Extreme: 2 boxes\n  - Epic: 3 boxes.\nAny allies who shared this vow also mark the reward.\n\nOn a __weak hit__, as above, but there is more to be done or you realize the truth of your quest. Envision what you discover (ask the oracle if unsure). If you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right, take your full legacy reward. Otherwise, mark the reward one rank lower.\n\nOn a __miss__, your quest is undone through an unexpected complication or realization. Envision what happens and choose one:\n  * Give up on the quest: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy).\n  * Recommit to the quest: Roll both challenge dice, take the lowest value, and clear that number of progress boxes. Then, raise the quest's rank by one (if not already epic).",
+          "text": "__Conclusion move.__ When you achieve what you believe to be the fulfillment of your promise, roll the challenge dice and compare to your progress. Focus is ignored on this roll.\n\nOn a __strong hit__, your quest is complete. Mark experience (troublesome=1; dangerous=2; formidable=3; extreme=4; epic=5).\n\nOn a __weak hit__, there is more to be done, or you realize the truth of your quest. Envision what you discover ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure). Then, mark experience (troublesome=0; dangerous=1; formidable=2; extreme=3; epic=4). You may [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right. If you do, add +1.\n\nOn a __miss__, your quest is undone. Envision what happens ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and choose one:\n  * You recommit: Clear all but one filled progress, and raise the quest’s rank by one (if not already epic).\n  * You give up: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy).",
           "tracks": {
             "category": "Quest",
             "controls": {}
@@ -4209,7 +4268,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 16,
+            "page": 6,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4235,7 +4294,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 15,
+            "page": 6,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4306,7 +4365,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 9,
+            "page": 12,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4337,7 +4396,7 @@
                     "max": 25,
                     "min": 11
                   },
-                  "text": "You are on the brink of your last death. You need to Heal within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death)."
+                  "text": "You are on the brink of your last death. You need to [Heal](datasworn:move:elegy/adventure/heal) within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death)."
                 },
                 {
                   "_id": "move.oracle_rollable.row:elegy/suffer/endure_harm.endure_harm.2",
@@ -4402,7 +4461,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 9,
+            "page": 13,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4433,7 +4492,7 @@
                     "max": 25,
                     "min": 11
                   },
-                  "text": "You are on the brink of starvation. You need to Feed within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death)."
+                  "text": "You are on the brink of starvation. You need to [Feed](datasworn:move:elegy/adventure/feed) within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death)."
                 },
                 {
                   "_id": "move.oracle_rollable.row:elegy/suffer/endure_hunger.endure_hunger.2",
@@ -4498,7 +4557,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 9,
+            "page": 14,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4529,7 +4588,7 @@
                     "max": 25,
                     "min": 11
                   },
-                  "text": "You give up. Forsake Your Elegy (if possible, one relevant to your current crisis)."
+                  "text": "You give up. [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy) (if possible, one relevant to your current crisis)."
                 },
                 {
                   "_id": "move.oracle_rollable.row:elegy/suffer/endure_stress.endure_stress.2",
@@ -4554,7 +4613,7 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/suffer/endure_stress.miss",
-              "text": "On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the list below."
+              "text": "On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the list below."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/suffer/endure_stress.strong_hit",
@@ -4566,7 +4625,7 @@
             }
           },
           "roll_type": "action_roll",
-          "text": "When you face mental shock or despair, suffer -spirit equal to your foe’s rank or as appropriate to the situation (see Stress). If your spirit is 0, suffer -focus equal to any remaining -spirit. Then, roll +Heart.\n\n- On a __strong hit__, choose one:\n  - Shake it off: If your spirit is greater than 0, suffer -1 focus in exchange for +1 spirit.\n  - Embrace the darkness: Take +1 focus.\n\n- On a __weak hit__, you press on.\n\n- On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the following table:\n\n{{table>move.oracle_rollable:elegy/suffer/endure_stress.endure_stress}}",
+          "text": "When you face mental shock or despair, suffer -spirit equal to your foe’s rank or as appropriate to the situation (see Stress). If your spirit is 0, suffer -focus equal to any remaining -spirit. Then, roll +Heart.\n\n- On a __strong hit__, choose one:\n  - Shake it off: If your spirit is greater than 0, suffer -1 focus in exchange for +1 spirit.\n  - Embrace the darkness: Take +1 focus.\n\n- On a __weak hit__, you press on.\n\n- On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the following table:\n\n{{table>move.oracle_rollable:elegy/suffer/endure_stress.endure_stress}}",
           "trigger": {
             "conditions": [
               {
@@ -4594,7 +4653,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 9,
+            "page": 11,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4603,7 +4662,7 @@
           "oracles": {},
           "outcomes": null,
           "roll_type": "no_roll",
-          "text": "When your focus is at its minimum (-6), and you suffer additional -focus, choose one:\n- Exchange each additional -focus for any combination of -health, -spirit, or -blood as appropriate to the circumstances.\n- Envision an event or discovery (ask the oracle if unsure) which undermines your progress in a current quest, journey, or fight. Then, for each additional -focus, clear 1 unit of progress on that track per its rank:\n  - Troublesome = clear 3 progress\n  - Dangerous = clear 2 progress\n  - Formidable = clear 1 progress\n  - Extreme = clear 2 ticks\n  - Epic = clear 1 tick",
+          "text": "When your focus is at its minimum (-6), and you suffer additional -focus, choose one:\n- Exchange each additional -focus for any combination of -health, -spirit, or -blood as appropriate to the circumstances.\n- Envision an event or discovery ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure) which undermines your progress in a current quest, journey, or fight. Then, for each additional -focus, clear 1 unit of progress on that track per its rank:\n  - Troublesome = clear 3 progress\n  - Dangerous = clear 2 progress\n  - Formidable = clear 1 progress\n  - Extreme = clear 2 ticks\n  - Epic = clear 1 tick",
           "trigger": {
             "conditions": [],
             "text": "When your focus is at its minimum (-6), and you suffer additional -focus..."
@@ -4620,7 +4679,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 10,
+            "page": 14,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4638,11 +4697,11 @@
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/suffer/face_desolation.weak_hit",
-              "text": "On a __weak hit__, choose one:\n- Your spirit or sanity breaks, but not before you make a noble sacrifice. Envision your final moments.\n- You see a vision of a dreaded event coming to pass. Envision that dark future, and Sing an Elegy (formidable or extreme) to prevent it. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest."
+              "text": "On a __weak hit__, choose one:\n- Your spirit or sanity breaks, but not before you make a noble sacrifice. Envision your final moments.\n- You see a vision of a dreaded event coming to pass. Envision that dark future ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to prevent it. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest."
             }
           },
           "roll_type": "action_roll",
-          "text": "When you are brought to the brink of desolation, roll +Heart.\n\n- On a __strong hit__, you resist and press on.\n\n- On a __weak hit__, choose one:\n  - Your spirit or sanity breaks, but not before you make a noble sacrifice. Envision your final moments.\n  - You see a vision of a dreaded event coming to pass. Envision that dark future, and Sing an Elegy (formidable or extreme) to prevent it. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest.\n\n- On a __miss__, you succumb to despair or horror and are lost.",
+          "text": "When you are brought to the brink of desolation, roll +Heart.\n\n- On a __strong hit__, you resist and press on.\n\n- On a __weak hit__, choose one:\n  - Your spirit or sanity breaks, but not before you make a noble sacrifice. Envision your final moments.\n  - You see a vision of a dreaded event coming to pass. Envision that dark future ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to prevent it. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest.\n\n- On a __miss__, you succumb to despair or horror and are lost.",
           "trigger": {
             "conditions": [
               {
@@ -4670,7 +4729,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 10,
+            "page": 12,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4688,11 +4747,11 @@
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/suffer/face_last_death.weak_hit",
-              "text": "On a __weak hit__, choose one:\n- You die, but not before making a noble sacrifice. Envision your final moments.\n- Death desires something of you in exchange for your unlife. Envision what it wants (ask the oracle if unsure), and Sing an Elegy (formidable or extreme) to complete that quest. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest."
+              "text": "On a __weak hit__, choose one:\n- You die, but not before making a noble sacrifice. Envision your final moments.\n- Death desires something of you in exchange for your unlife. Envision what it wants ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to complete that quest. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest."
             }
           },
           "roll_type": "action_roll",
-          "text": "When you are brought to the brink of your annihilation, and glimpse the world beyond, roll +Heart.\n\n- On a __strong hit__, you are cast back into the mortal world.\n\n- On a __weak hit__, choose one:\n  - You die, but not before making a noble sacrifice. Envision your final moments.\n  - Death desires something of you in exchange for your unlife. Envision what it wants (ask the oracle if unsure), and Sing an Elegy (formidable or extreme) to complete that quest. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest.\n\n- On a __miss__, you are destroyed.",
+          "text": "When you are brought to the brink of your annihilation, and glimpse the world beyond, roll +Heart.\n\n- On a __strong hit__, you are cast back into the mortal world.\n\n- On a __weak hit__, choose one:\n  - You die, but not before making a noble sacrifice. Envision your final moments.\n  - Death desires something of you in exchange for your unlife. Envision what it wants ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to complete that quest. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest.\n\n- On a __miss__, you are destroyed.",
           "trigger": {
             "conditions": [
               {
@@ -4721,7 +4780,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 10,
+            "page": 13,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4731,7 +4790,7 @@
           "outcomes": {
             "miss": {
               "_id": "move.outcome:elegy/suffer/face_starvation.miss",
-              "text": "On a __miss__, your hunger destroys your humanity and..."
+              "text": "On a __miss__, your hunger destroys your humanity and you are forever a mindless beast."
             },
             "strong_hit": {
               "_id": "move.outcome:elegy/suffer/face_starvation.strong_hit",
@@ -4739,11 +4798,11 @@
             },
             "weak_hit": {
               "_id": "move.outcome:elegy/suffer/face_starvation.weak_hit",
-              "text": "On a __weak hit__, choose one:\n- Your humanity is devoured, but not before remembering a moment of your mortal life. Envision what flashes behind your eyes.\n- You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and Sing an Elegy to her (formidable or extreme)."
+              "text": "On a __weak hit__, choose one:\n- Your humanity is devoured, but not before remembering a moment of your mortal life. Envision what flashes behind your eyes.\n- You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to her (formidable or extreme)."
             }
           },
           "roll_type": "action_roll",
-          "text": "When you are brought to the brink of starvation, roll +Intellect.\n\n- On a __strong hit__, you resist and press on.\n\n- On a __weak hit__, choose one:\n  - Your humanity is devoured, but not before remembering a moment of your mortal life. Envision what flashes behind your eyes.\n  - You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and Sing an Elegy to her (formidable or extreme).\n\n- On a __miss__, your hunger destroys your humanity and...",
+          "text": "When you are brought to the brink of starvation, roll +Intellect.\n\n- On a __strong hit__, you resist and press on.\n\n- On a __weak hit__, choose one:\n  - Your humanity is devoured, but not before remembering a moment of your mortal life. Envision what flashes behind your eyes.\n  - You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to her (formidable or extreme).\n\n- On a __miss__, your hunger destroys your humanity and you are forever a mindless beast.",
           "trigger": {
             "conditions": [
               {
@@ -4772,7 +4831,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 7,
+            "page": 11,
             "title": "Elegy 3.5 Moves",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -4955,7 +5014,7 @@
           },
           "outcomes": null,
           "roll_type": "no_roll",
-          "text": "When you suffer the outcome of an action, choose one:\n- Make the most obvious negative outcome happen.\n- Ask the oracle for inspiration. Interpret the answer as a hardship or complication appropriate to the situation.\n- Roll on the list below. If the result doesn’t fit the situation, roll again.\n\n{{table>move.oracle_rollable:elegy/suffer/pay_the_price.pay_the_price}}\n  ",
+          "text": "When you suffer the outcome of an action, choose one:\n- Make the most obvious negative outcome happen.\n- [Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) for inspiration. Interpret the answer as a hardship or complication appropriate to the situation.\n- Roll on the list below. If the result doesn’t fit the situation, roll again.\n\n{{table>move.oracle_rollable:elegy/suffer/pay_the_price.pay_the_price}}\n  ",
           "trigger": {
             "conditions": [],
             "text": "When you suffer the outcome of an action..."
@@ -5410,9 +5469,9 @@
             }
           ],
           "suggestions": [
-            "oracle_rollable:classic/action_and_theme/theme"
+            "oracle_rollable:elegy/action_and_theme/themes"
           ],
-          "summary": "Use this table to inspire a discovery, event, character goal, or situation. A roll on this table can be combined with a [Theme](datasworn:oracle_rollable:classic/action_and_theme/theme) to provide an action and a subject. Then, interpret the result based on the context of the question and your current situation.",
+          "summary": "Use this table to inspire a discovery, event, character goal, or situation. A roll on this table can be combined with a [Theme](datasworn:oracle_rollable:elegy/action_and_theme/themes) to provide an action and a subject. Then, interpret the result based on the context of the question and your current situation.",
           "type": "oracle_rollable"
         },
         "descriptors": {
@@ -6299,6 +6358,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 140,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -6725,6 +6785,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 139,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -7171,6 +7232,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 135,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -7277,6 +7339,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 135,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -7543,6 +7606,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 135,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -7969,6 +8033,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 135,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -9242,7 +9307,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
-            "page": 134,
+            "page": 133,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -10089,6 +10154,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 137,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -10515,6 +10581,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 136,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -10941,6 +11008,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 137,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -11251,6 +11319,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 142,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -11325,6 +11394,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 142,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -11431,6 +11501,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 141,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -11697,7 +11768,7 @@
                 "max": 32,
                 "min": 32
               },
-              "text": "Music Venue"
+              "text": "Yoga Studio"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.32",
@@ -11705,7 +11776,7 @@
                 "max": 33,
                 "min": 33
               },
-              "text": "Grocery Store"
+              "text": "Music Venue"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.33",
@@ -11713,7 +11784,7 @@
                 "max": 34,
                 "min": 34
               },
-              "text": "Park Bench"
+              "text": "Grocery Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.34",
@@ -11721,7 +11792,7 @@
                 "max": 35,
                 "min": 35
               },
-              "text": "Public Pool"
+              "text": "Park Bench"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.35",
@@ -11729,7 +11800,7 @@
                 "max": 36,
                 "min": 36
               },
-              "text": "Laundromat"
+              "text": "Public Pool"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.36",
@@ -11737,7 +11808,7 @@
                 "max": 37,
                 "min": 37
               },
-              "text": "Pharmacy"
+              "text": "Laundromat"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.37",
@@ -11745,7 +11816,7 @@
                 "max": 38,
                 "min": 38
               },
-              "text": "Hardware Store"
+              "text": "Pharmacy"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.38",
@@ -11753,7 +11824,7 @@
                 "max": 39,
                 "min": 39
               },
-              "text": "Bike Shop"
+              "text": "Hardware Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.39",
@@ -11761,7 +11832,7 @@
                 "max": 40,
                 "min": 40
               },
-              "text": "Food Truck Park"
+              "text": "Bike Shop"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.40",
@@ -11769,7 +11840,7 @@
                 "max": 41,
                 "min": 41
               },
-              "text": "Public Restroom"
+              "text": "Food Truck Park"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.41",
@@ -11777,7 +11848,7 @@
                 "max": 42,
                 "min": 42
               },
-              "text": "Office Building"
+              "text": "Public Restroom"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.42",
@@ -11785,7 +11856,7 @@
                 "max": 43,
                 "min": 43
               },
-              "text": "Beauty Salon"
+              "text": "Office Building"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.43",
@@ -11793,7 +11864,7 @@
                 "max": 44,
                 "min": 44
               },
-              "text": "Gas Station"
+              "text": "Beauty Salon"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.44",
@@ -11801,7 +11872,7 @@
                 "max": 45,
                 "min": 45
               },
-              "text": "Food Court"
+              "text": "Gas Station"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.45",
@@ -11809,7 +11880,7 @@
                 "max": 46,
                 "min": 46
               },
-              "text": "Library"
+              "text": "Food Court"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.46",
@@ -11817,7 +11888,7 @@
                 "max": 47,
                 "min": 47
               },
-              "text": "Skate Park"
+              "text": "Library"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.47",
@@ -11825,7 +11896,7 @@
                 "max": 48,
                 "min": 48
               },
-              "text": "Tennis Court"
+              "text": "Skate Park"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.48",
@@ -11833,7 +11904,7 @@
                 "max": 49,
                 "min": 49
               },
-              "text": "Playground"
+              "text": "Tennis Court"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.49",
@@ -11841,7 +11912,7 @@
                 "max": 50,
                 "min": 50
               },
-              "text": "Mini Golf Course"
+              "text": "Playground"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.50",
@@ -11849,7 +11920,7 @@
                 "max": 51,
                 "min": 51
               },
-              "text": "Car Dealership"
+              "text": "Mini Golf Course"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.51",
@@ -11857,7 +11928,7 @@
                 "max": 52,
                 "min": 52
               },
-              "text": "Bowling Alley"
+              "text": "Car Dealership"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.52",
@@ -11865,7 +11936,7 @@
                 "max": 53,
                 "min": 53
               },
-              "text": "Dog Park"
+              "text": "Bowling Alley"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.53",
@@ -11873,7 +11944,7 @@
                 "max": 54,
                 "min": 54
               },
-              "text": "Golf Course"
+              "text": "Dog Park"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.54",
@@ -11881,7 +11952,7 @@
                 "max": 55,
                 "min": 55
               },
-              "text": "Police Academy"
+              "text": "Golf Course"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.55",
@@ -11889,7 +11960,7 @@
                 "max": 56,
                 "min": 56
               },
-              "text": "Bus Stop"
+              "text": "Police Academy"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.56",
@@ -11897,7 +11968,7 @@
                 "max": 57,
                 "min": 57
               },
-              "text": "Comedy Club"
+              "text": "Bus Stop"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.57",
@@ -11905,7 +11976,7 @@
                 "max": 58,
                 "min": 58
               },
-              "text": "Flower Shop"
+              "text": "Comedy Club"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.58",
@@ -11913,7 +11984,7 @@
                 "max": 59,
                 "min": 59
               },
-              "text": "Antique Store"
+              "text": "Flower Shop"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.59",
@@ -11921,7 +11992,7 @@
                 "max": 60,
                 "min": 60
               },
-              "text": "Yoga Studio"
+              "text": "Antique Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.60",
@@ -11929,7 +12000,7 @@
                 "max": 61,
                 "min": 61
               },
-              "text": "Movie Rental Store"
+              "text": "Yoga Studio"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.61",
@@ -11937,7 +12008,7 @@
                 "max": 62,
                 "min": 62
               },
-              "text": "Music Store"
+              "text": "Movie Rental Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.62",
@@ -11945,7 +12016,7 @@
                 "max": 63,
                 "min": 63
               },
-              "text": "Garden"
+              "text": "Music Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.63",
@@ -11953,7 +12024,7 @@
                 "max": 64,
                 "min": 64
               },
-              "text": "Pawn Shop"
+              "text": "Garden"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.64",
@@ -11961,7 +12032,7 @@
                 "max": 65,
                 "min": 65
               },
-              "text": "Escape Room"
+              "text": "Pawn Shop"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.65",
@@ -11969,7 +12040,7 @@
                 "max": 66,
                 "min": 66
               },
-              "text": "Art Supply Store"
+              "text": "Escape Room"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.66",
@@ -11977,7 +12048,7 @@
                 "max": 67,
                 "min": 67
               },
-              "text": "Thrift Store"
+              "text": "Art Supply Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.67",
@@ -11985,7 +12056,7 @@
                 "max": 68,
                 "min": 68
               },
-              "text": "Dance Studio"
+              "text": "Thrift Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.68",
@@ -11993,7 +12064,7 @@
                 "max": 69,
                 "min": 69
               },
-              "text": "Recording Studio"
+              "text": "Dance Studio"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.69",
@@ -12001,7 +12072,7 @@
                 "max": 70,
                 "min": 70
               },
-              "text": "Boxing Gym"
+              "text": "Recording Studio"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.70",
@@ -12009,7 +12080,7 @@
                 "max": 71,
                 "min": 71
               },
-              "text": "Hardware Store"
+              "text": "Boxing Gym"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.71",
@@ -12017,7 +12088,7 @@
                 "max": 72,
                 "min": 72
               },
-              "text": "Brewery"
+              "text": "Hardware Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.72",
@@ -12025,7 +12096,7 @@
                 "max": 73,
                 "min": 73
               },
-              "text": "Music School"
+              "text": "Brewery"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.73",
@@ -12033,7 +12104,7 @@
                 "max": 74,
                 "min": 74
               },
-              "text": "Theater Company"
+              "text": "Music School"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.74",
@@ -12041,7 +12112,7 @@
                 "max": 75,
                 "min": 75
               },
-              "text": "Retirement Home"
+              "text": "Theater Company"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.75",
@@ -12049,7 +12120,7 @@
                 "max": 76,
                 "min": 76
               },
-              "text": "Auto Repair Shop"
+              "text": "Retirement Home"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.76",
@@ -12057,7 +12128,7 @@
                 "max": 77,
                 "min": 77
               },
-              "text": "Paintball Arena"
+              "text": "Auto Repair Shop"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.77",
@@ -12065,7 +12136,7 @@
                 "max": 78,
                 "min": 78
               },
-              "text": "Farmers Market"
+              "text": "Paintball Arena"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.78",
@@ -12073,7 +12144,7 @@
                 "max": 79,
                 "min": 79
               },
-              "text": "Trampoline Park"
+              "text": "Farmers Market"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.79",
@@ -12081,7 +12152,7 @@
                 "max": 80,
                 "min": 80
               },
-              "text": "Karaoke Bar"
+              "text": "Trampoline Park"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.80",
@@ -12089,7 +12160,7 @@
                 "max": 81,
                 "min": 81
               },
-              "text": "Board Game Cafe"
+              "text": "Karaoke Bar"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.81",
@@ -12097,7 +12168,7 @@
                 "max": 82,
                 "min": 82
               },
-              "text": "Comic Book Store"
+              "text": "Board Game Cafe"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.82",
@@ -12105,7 +12176,7 @@
                 "max": 83,
                 "min": 83
               },
-              "text": "Furniture Store"
+              "text": "Comic Book Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.83",
@@ -12113,7 +12184,7 @@
                 "max": 84,
                 "min": 84
               },
-              "text": "Tailor Shop"
+              "text": "Furniture Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.84",
@@ -12121,7 +12192,7 @@
                 "max": 85,
                 "min": 85
               },
-              "text": "Yoga Studio"
+              "text": "Tailor Shop"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.85",
@@ -12129,7 +12200,7 @@
                 "max": 86,
                 "min": 86
               },
-              "text": "Dance Club"
+              "text": "Yoga Studio"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.86",
@@ -12137,7 +12208,7 @@
                 "max": 87,
                 "min": 87
               },
-              "text": "Gym"
+              "text": "Dance Club"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.87",
@@ -12145,7 +12216,7 @@
                 "max": 88,
                 "min": 88
               },
-              "text": "Skate Shop"
+              "text": "Gym"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.88",
@@ -12153,7 +12224,7 @@
                 "max": 89,
                 "min": 89
               },
-              "text": "Shooting Range"
+              "text": "Skate Shop"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.89",
@@ -12161,7 +12232,7 @@
                 "max": 90,
                 "min": 90
               },
-              "text": "Home Decor Store"
+              "text": "Shooting Range"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.90",
@@ -12169,7 +12240,7 @@
                 "max": 91,
                 "min": 91
               },
-              "text": "Juice Bar"
+              "text": "Home Decor Store"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.91",
@@ -12177,7 +12248,7 @@
                 "max": 92,
                 "min": 92
               },
-              "text": "Pottery Studio"
+              "text": "Juice Bar"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.92",
@@ -12185,7 +12256,7 @@
                 "max": 93,
                 "min": 93
               },
-              "text": "Tea House"
+              "text": "Pottery Studio"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.93",
@@ -12193,7 +12264,7 @@
                 "max": 94,
                 "min": 94
               },
-              "text": "Boxing Studio"
+              "text": "Tea House"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.94",
@@ -12201,7 +12272,7 @@
                 "max": 95,
                 "min": 95
               },
-              "text": "Arts Center"
+              "text": "Boxing Studio"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.95",
@@ -12209,7 +12280,7 @@
                 "max": 96,
                 "min": 96
               },
-              "text": "Go-Kart Track"
+              "text": "Arts Center"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.96",
@@ -12217,7 +12288,7 @@
                 "max": 97,
                 "min": 97
               },
-              "text": "Laser Tag Arena"
+              "text": "Go-Kart Track"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.97",
@@ -12225,13 +12296,21 @@
                 "max": 98,
                 "min": 98
               },
-              "text": "Retro Arcade"
+              "text": "Laser Tag Arena"
             },
             {
               "_id": "oracle_rollable.row:elegy/text/generic.98",
               "roll": {
                 "max": 99,
                 "min": 99
+              },
+              "text": "Retro Arcade"
+            },
+            {
+              "_id": "oracle_rollable.row:elegy/text/generic.99",
+              "roll": {
+                "max": 100,
+                "min": 100
               },
               "text": "Outdoor Concert Venue"
             }
@@ -12249,6 +12328,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 142,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -12355,6 +12435,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 142,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -12461,6 +12542,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 142,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -12567,6 +12649,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 142,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -12673,6 +12756,7 @@
             ],
             "date": "2024-07-31",
             "license": "https://creativecommons.org/licenses/by-nc-sa/4.0",
+            "page": 142,
             "title": "Elegy 3.5",
             "url": "https://miraclem.itch.io/elegy"
           },
@@ -12784,7 +12868,7 @@
         "max": 5,
         "min": 0,
         "rollable": true,
-        "shared": true,
+        "shared": false,
         "value": 5
       },
       "health": {
@@ -12807,37 +12891,57 @@
       }
     },
     "impacts": {
+      "burdens": {
+        "contents": {
+          "cursed": {
+            "description": "Cursed is marked when you [Face Last Death](datasworn:move:elegy/suffer/face_last_death) and return to the mortal world with a soul-bound quest. This burden can only be cleared by completing the quest.",
+            "label": "cursed",
+            "permanent": false,
+            "prevents_recovery": [],
+            "shared": false
+          },
+          "tormented": {
+            "description": "Tormented is marked when you [Face Desolation](datasworn:move:elegy/suffer/face_desolation), gain visions of a dreaded event coming to pass, and undertake a quest to prevent it. This burden can only be cleared by completing the quest.",
+            "label": "tormented",
+            "permanent": false,
+            "prevents_recovery": [],
+            "shared": false
+          }
+        },
+        "description": "Burdens are a result of life-changing experiences that leave you bound to quests. Clearing a burden can only be accomplished by resolving the quest.",
+        "label": "burdens"
+      },
       "lasting_effects": {
         "contents": {
           "permanently_harmed": {
-            "description": "Permanently harmed may be marked when you are at 0 health and fail to [Endure Harm](datasworn:move:starforged/suffer/endure_harm). You have suffered a wound that you must reckon with, such as the loss of an eye or hand. Or you bear physical scars that are a constant reminder of a harrowing incident.",
+            "description": "Permanently harmed may be marked when you are Wounded, at 0 health, and suffer harm ([Endure Harm](datasworn:move:elegy/suffer/endure_harm)). You have suffered a wound that you must reckon with, such as the loss of an eye or hand, or bear physical scars that are a constant reminder of a harrowing incident. When this impact is marked, you have 0 health and if you suffer more harm, you die your last death.",
             "label": "permanently harmed",
             "permanent": true,
             "prevents_recovery": [],
             "shared": false
           },
           "sinner": {
-            "description": "Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood and you spend more blood, you lose complete touch with your human side and turn into a beast.",
+            "description": "Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood. If you spend more blood, you lose complete touch with your human side and turn into a beast.",
             "label": "sinner",
             "permanent": true,
             "prevents_recovery": [],
             "shared": false
           },
           "traumatized": {
-            "description": "Traumatized may be marked when you are at 0 spirit and fail to [Endure Stress](datasworn:move:starforged/suffer/endure_stress). Your experiences have left you emotionally or mentally scarred.",
+            "description": "Traumatized may be marked when you are Shaken, at 0 spirit, and suffer stress ([Endure Stress](datasworn:move:elegy/suffer/endure_stress)). Your experiences have left you emotionally or mentally scarred. When this impact is marked, you have 0 spirit and if you suffer more stress, your mind is forever lost.",
             "label": "traumatized",
             "permanent": true,
             "prevents_recovery": [],
             "shared": false
           }
         },
-        "description": "Lasting effects are permanent. They forever impact your character through the momentum adjustment and—more importantly—the narrative impact of being permanently harmed or traumatized. You should factor this impact into how you perform moves and how you interact with the world.",
+        "description": "Lasting effects are permanent. They forever impact your character through the focus adjustment and—more importantly—the narrative impact of being permanently harmed or traumatized. You should factor this impact into how you perform moves and how you interact with the world.",
         "label": "lasting effects"
       },
       "misfortunes": {
         "contents": {
           "shaken": {
-            "description": "Shaken may be marked when you are at 0 spirit and fail to [Endure Stress](datasworn:move:starforged/suffer/endure_stress). You are despairing or distraught.",
+            "description": "Shaken is marked when you are at 0 spirit and suffer stress ([Endure Stress](datasworn:move:elegy/suffer/endure_stress)). You are despairing or distraught.",
             "label": "shaken",
             "permanent": false,
             "prevents_recovery": [
@@ -12849,11 +12953,14 @@
             "description": "Starving is marked when you are at 0 blood and lose blood. You are in a violent, hungry state. You lose 1 point of glamour and 1 of intellect.",
             "label": "starving",
             "permanent": false,
-            "prevents_recovery": [],
-            "shared": true
+            "prevents_recovery": [
+              "spirit",
+              "blood"
+            ],
+            "shared": false
           },
           "wounded": {
-            "description": "Wounded may be marked when you are at 0 health and fail to [Endure Harm](datasworn:move:starforged/suffer/endure_harm). You are severely injured.",
+            "description": "Wounded may be marked when you are at 0 health and suffer harm ([Endure Harm](datasworn:move:elegy/suffer/endure_harm)). You are severely injured.",
             "label": "wounded",
             "permanent": false,
             "prevents_recovery": [
@@ -12871,12 +12978,7 @@
         "description": "Sing elegies and do what you must to see them fulfilled.",
         "label": "elegies",
         "optional": false,
-        "shared": false,
-        "tags": {
-          "starforged": {
-            "legacy_track_xp": true
-          }
-        }
+        "shared": false
       }
     },
     "stats": {
@@ -12905,7 +13007,7 @@
   },
   "site_domains": {},
   "site_themes": {},
-  "title": "Elegy 3.5 truths",
+  "title": "Elegy 3.5",
   "truths": {
     "blood_sorcery": {
       "_id": "truth:elegy/blood_sorcery",
@@ -12926,36 +13028,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/blood_sorcery.0",
-          "description": "Only a few vampires dare to practice this dangerous magic, as it is heavily restricted by vampire law.",
+          "description": "While some individuals may follow peculiar esoteric traditions, the concept of vampiric blood sorcery is nonexistent in our world. Rituals are not a part of our reality.",
           "oracles": {},
-          "quest_starter": "A powerful sorcerer demands a rare ingredient for a ritual. Why do you choose to aid—or oppose—them?",
+          "quest_starter": "A vampire is conducting mystical ceremonies involving animal sacrifice. The disappearance of numerous animals is making mortal society suspicious. How do you make her stop? What is her favorite animal to sacrifice, and why?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Blood sorcery is a rare and forbidden art."
+          "summary": "The powers of blood don’t manifest themselves through silly rituals"
         },
         {
           "_id": "truth.option:elegy/blood_sorcery.1",
-          "description": "Many vampires use blood sorcery to enhance their powers, though it often comes with significant risks and costs.",
+          "description": "They keep out of sight, so their methods stay secret, but they sometimes take vampires as pupils when they are worthy.",
           "oracles": {},
-          "quest_starter": "A rival vampire challenges you to a duel of sorcery. What stakes do you set, and how do you prepare?",
+          "quest_starter": "Rumors say there’s an elder in Santa Maria who could teach you rituals — if you manage to find and convince her. Why are you so eager to be her apprentice? Where will you start looking for her?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Blood sorcery is widely practiced."
+          "summary": "Vampires who know blood sorcery rituals are rare, but often powerful and wise."
         },
         {
           "_id": "truth.option:elegy/blood_sorcery.2",
-          "description": "No one fully understands the origins or mechanics of blood sorcery, making it a source of both fascination and fear.",
+          "description": "They are meticulous in their studies, developing complex rituals, and mastering the manipulation of supernatural forces. Their focus on the arcane arts gives them a reputation for being scholars and guardians of occult knowledge within the vampire society. This alternative gives access to the Circle of Circe NPCs.",
           "oracles": {},
-          "quest_starter": "An ancient text detailing lost sorceries has been uncovered. What lengths will you go to obtain it?",
+          "quest_starter": "A bag of werewolf blood has been located in the local medical clinic. This not only endangers the Façade, as it would make a potent concoction for rituals, according to the vampire that contacts you. Why are you trusted with this quest? What do you get in return?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Blood sorcery is mysterious and unpredictable."
+          "summary": "The Circle of Circe is a large, influential group of vampire mystics."
         }
       ],
       "type": "truth"
@@ -12979,36 +13081,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/deviance.0",
-          "description": "Most vampires adhere strictly to tradition and the Façade, avoiding behaviors that could endanger their kind.",
+          "description": "Everybody has heard of a vampire drinking the blood of another, turning mortals into vampires without thinking twice, or even revealing their nature despite the risk, but they’re really abnormal cases.",
           "oracles": {},
-          "quest_starter": "A young vampire's reckless actions threaten the Façade. How do you intervene?",
+          "quest_starter": "You hear rumors of a group of vampires killing others to use their vampiric blood to conduct dark, esoteric rites. What’s their story? What do they seek through these rites? Why do you swear to stop them?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Deviance is rare among vampires."
+          "summary": "Vampires rarely break the three moral laws buried within their nature."
         },
         {
           "_id": "truth.option:elegy/deviance.1",
-          "description": "Some vampires challenge traditions and norms, creating conflict within vampire society.",
+          "description": "They embrace a more anarchic and brutal existence, engaging in open warfare against their enemies and resorting to violence. This alternative gives access to the Egregoros NPCs.",
           "oracles": {},
-          "quest_starter": "A group of deviant vampires invites you to join them. What do they offer, and what risks does this pose?",
+          "quest_starter": "Rumors say the Egregoros are planning to turn a serial killer into a vampire in one of their macabre rituals. How will you stop their plans?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Deviance is a growing problem."
+          "summary": "A large group of vampires called the Egregoros rejects the three basic vampire laws and opposes anyone standing by them."
         },
         {
           "_id": "truth.option:elegy/deviance.2",
-          "description": "Many vampires have abandoned traditional rules, forcing society to adapt or risk collapse.",
+          "description": "They usually do it to establish a relationship of dominance and influence over the other individual.",
           "oracles": {},
-          "quest_starter": "A powerful vampire leader plans to reform society to accommodate deviance. What role do you play in their plans?",
+          "quest_starter": "A nightclub owner is compelling her human employees to drink her blood, binding them as servants through blood linking. They exhibit extreme submissiveness towards her, but tensions arise as they begin to compete for their employer’s favor. Why do you intervene in this situation?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Deviance is widespread."
+          "summary": "Vampires who create blood links with others of their kind or even mortals are common."
         }
       ],
       "type": "truth"
@@ -13032,36 +13134,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/elegies.0",
-          "description": "These haunting songs of loss and memory have faded from vampire society, known only to the oldest among them.",
+          "description": "It can be a letter paper, a notebook page or even a napkin. Regardless of the material, it is treated as a contract. After singing an elegy, a vampire sheds a drop of blood on it and hands it to the one to whom she has sworn — or puts it in a safe place if she made the promise to herself.",
           "oracles": {},
-          "quest_starter": "An ancient vampire offers to teach you an elegy. What must you do to earn their trust?",
+          "quest_starter": "Your progenitor writes her elegies in a special paper collection she owns. However, this collection was unfortunately stolen. What will you do to the culprit? Why is this collection so important?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Elegies are forgotten."
+          "summary": "…are documents written on paper and marked with a drop of blood."
         },
         {
           "_id": "truth.option:elegy/elegies.1",
-          "description": "Vampires maintain a rich tradition of elegies, which serve as both art and history.",
+          "description": "Elegies are crafted like any promise, whether written or spoken. The vampire who creates one dedicates a few minutes to half an hour in silence and solitude, concentrating on it and visualizing its fulfillment.",
           "oracles": {},
-          "quest_starter": "A rival vampire challenges you to perform an elegy at a gathering. How do you prepare, and what story do you choose to tell?",
+          "quest_starter": "While you were meditating on an elegy, the vivid image of a vampire smiling at you suddenly appeared in your mind. What strong emotion did this make you feel? Why does her appearance evoke in you a desire to discover who she is?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Elegies are preserved."
+          "summary": "…are made verbally and contemplated in meditation."
         },
         {
           "_id": "truth.option:elegy/elegies.2",
-          "description": "Modern vampires have adapted elegies to contemporary styles, blending old and new in innovative ways.",
+          "description": "After a vampire sings an elegy to another individual, each one bites her own palm. They then shake hands, allowing the blood of both to intermingle. When a vampire sings an elegy for herself, she bites both hands and holds them together.",
           "oracles": {},
-          "quest_starter": "A young vampire creates a controversial new elegy. How do you react, and what does it mean for vampire society?",
+          "quest_starter": "According to your progenitor, the mummified hand of an ancient vampire is somewhere in Santa Maria.",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Elegies are evolving."
+          "summary": "…are sealed by a bloody handshake."
         }
       ],
       "type": "truth"
@@ -13085,36 +13187,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/genealogy.0",
-          "description": "All vampires trace their lineage back to a single source, creating a complex web of relationships and responsibilities.",
+          "description": "Every vampire is affiliated with one of several “families,” each characterized by distinct traditions and manifestations of vampirism. Lineages are transmitted when one vampire creates another, with each lineage embodying a specific archetype of the vampire myth, bestowing unique powers and inclinations. Members of a lineage may not necessarily resemble or behave like each other. This alternative enables the Lineages optional rule in page 76.",
           "oracles": {},
-          "quest_starter": "A lost lineage chart has resurfaced, revealing the connections between several powerful vampires. Who has it, and why is it causing turmoil?",
+          "quest_starter": "A vampire serial killer is targeting victims of a specific lineage. Which one is it, and why? What compels you to step forward and go after her?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Vampires share a single progenitor."
+          "summary": "Depending on their progenitor, each vampire belongs to one of five different lineages."
         },
         {
           "_id": "truth.option:elegy/genealogy.1",
-          "description": "Each clan has its own unique characteristics, powers, and traditions, often leading to rivalries.",
+          "description": "Vampirism manifests in what seems like a random manner, and each vampire is a unique entity with its own set of features.",
           "oracles": {},
-          "quest_starter": "A clan leader has gone missing, throwing their followers into disarray. What role do you play in this power vacuum?",
+          "quest_starter": "A newborn vampire went missing. You know she had a unique ability, which should help you track her. What ability is this? Why do you swear to find the newborn?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Vampires are divided into distinct clans or families."
+          "summary": "All vampires are unique and different from one another."
         },
         {
           "_id": "truth.option:elegy/genealogy.2",
-          "description": "Most vampires avoid forming large communities, preferring independence and secrecy, but some exceptions exist.",
+          "description": "While powers may develop in a more diverse fashion over time, all new vampires begin their undead existence inheriting one special ability from their progenitor. This ability is random.",
           "oracles": {},
-          "quest_starter": "An enigmatic vampire is attempting to unite solitary vampires under a single banner. Why does this concern you?",
+          "quest_starter": "Two newborn vampires don’t know where they come from, but believe they share the same progenitor. What power do they share? Why do you agree to help? Who is the progenitor?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Vampires are solitary by nature."
+          "summary": "Vampires inherit one power from their progenitor."
         }
       ],
       "type": "truth"
@@ -13191,36 +13293,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/mortal_magic.0",
-          "description": "Magic is rare among mortals, and those who wield it are often unaware of their potential.",
+          "description": "They follow their own individual path into magical enlightenment. This alternative gives access to the Crystal Compass NPCs.",
           "oracles": {},
-          "quest_starter": "A mortal accidentally casts a spell that reveals vampire activity. How do you address the situation?",
+          "quest_starter": "Your progenitor suspects a mage from the Crystal Compass is plotting to assassinate her other progeny. What evidence does she have? How will you stop this assassin?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Mortals rarely possess magic."
+          "summary": "The Crystal Compass is a global mage organization."
         },
         {
           "_id": "truth.option:elegy/mortal_magic.1",
-          "description": "Mortals are beginning to harness magic deliberately, posing new challenges for vampires.",
+          "description": "They’re not that many or that powerful. When they’re organized, they form small groups. This alternative gives access to the Occultist Mortal NPC.",
           "oracles": {},
-          "quest_starter": "A group of mortal sorcerers forms a pact to hunt vampires. How do you confront them?",
+          "quest_starter": "Occultists are conducting rituals on a beach that belongs to an elder, attracting mortal attention. What do you get in return for stopping them? What do their bizarre rituals involve?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Mortal magic is an emerging threat."
+          "summary": "There are a few occultists in Santa Maria."
         },
         {
           "_id": "truth.option:elegy/mortal_magic.2",
-          "description": "Mortals with magic are formidable adversaries, and some vampires even seek alliances with them.",
+          "description": "Nothing will happen if they try to cast a spell or perform a ritual.",
           "oracles": {},
-          "quest_starter": "A mortal magician offers you a powerful enchantment—for a price. What do they demand, and how do you respond?",
+          "quest_starter": "A mortal who claims to be a vampire is being accused of practicing dark magic by their neighbor. Why do you swear to defuse this situation?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Mortal magic rivals vampiric powers."
+          "summary": "Human beings have no supernatural power."
         }
       ],
       "type": "truth"
@@ -13244,36 +13346,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/origins.0",
-          "description": "Vampires are their own species, integral to the balance of the world’s ecosystem, albeit in a supernatural way.",
+          "description": "Ages ago, vampires already believed they were integral to the balance of the world’s ecosystem, if not in a natural way, in a supernatural one.",
           "oracles": {},
           "quest_starter": "A renowned biologist is conducting an experiment on vampire blood, threatening the Façade. How do you get involved in this situation? How do you plan to silence her?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Vampirism is a genetic mutation."
+          "summary": "…a genetic mutation, and vampires are their own species."
         },
         {
           "_id": "truth.option:elegy/origins.1",
-          "description": "The curse unfolded when the first murder occurred, and a higher power condemned the killer and her descendants to an eternal nocturnal existence.",
+          "description": "The curse unfolded when the first murder occurred, and a higher power condemned the killer and her descendants, ensuring they would never again walk under the sun. This marked the origin of the first vampire.",
           "oracles": {},
           "quest_starter": "A cryptic parchment telling the story of the first murder has been found. It’s in a strange language, and it seems to reveal new details of the story. How will you translate it? What details are these?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Vampirism is a punishment for humanity’s original sins."
+          "summary": "…a punishment for humanity’s original sins."
         },
         {
           "_id": "truth.option:elegy/origins.2",
-          "description": "Even the most enlightened vampires harbor conflicting opinions on this matter, and there is no definitive answer.",
+          "description": "Even the most enlightened vampires harbor conflicting opinions on this matter. Each individual’s perspective significantly shapes their interpretation, and there is no definitive answer to this question.",
           "oracles": {},
           "quest_starter": "Vampires form a cult around the idea that it’s possible to turn back into mere humans, but mortal authorities suspect something is not right with them. Why do you step in this situation?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Vampirism is an eternal enigma."
+          "summary": "…an eternal enigma."
         }
       ],
       "type": "truth"
@@ -13297,36 +13399,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/rebels.0",
-          "description": "Dissatisfied with the current order, these vampires aim to dismantle traditional hierarchies and establish a new regime.",
+          "description": "These groups can be united by any social or political idea. The bigger ones can even have some influence, but they are never powerful enough to actually challenge the queen.",
           "oracles": {},
-          "quest_starter": "A rebel leader offers you a place in their ranks. Why do you consider—or reject—their offer?",
+          "quest_starter": "A small group of vampires is accusing and exposing a corrupt, bloodthirsty captain they want to take down. Why is taking part in this situation important to you? Who do you support?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Rebels seek to overthrow vampire society."
+          "summary": "Plenty of vampires don’t agree totally with the queen, and sometimes they form groups."
         },
         {
           "_id": "truth.option:elegy/rebels.1",
-          "description": "Not all rebels seek revolution; some fight for changes within the system, targeting outdated customs or oppressive practices.",
+          "description": "The queen’s law is absolute. Any organized political divergence from the traditions that hold her in power is a threat that must be eliminated.",
           "oracles": {},
-          "quest_starter": "A group of young vampires begins to protest a centuries-old law. How do you become involved in their movement?",
+          "quest_starter": "Your progenitor was accused of conspiring against the queen. Written evidence that connects her to a radical group was found, but she swears the letters are forged. Who is the culprit?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Rebels challenge specific norms."
+          "summary": "Those who don’t agree with the queen’s rule will be silenced or punished."
         },
         {
           "_id": "truth.option:elegy/rebels.2",
-          "description": "Rebels are a fringe element, shunned and hunted by mainstream vampire society for their defiance.",
+          "description": "They advocate for individual freedom and self-governance, and resist the constraints of the queen’s law. While their ranks include diverse ideologies, from idealists to nihilists, the common thread among them is a desire to challenge authority, question ancient traditions, and create a more egalitarian and liberated existence for vampires. This alternative gives access to the Agorean Movement NPCs.",
           "oracles": {},
-          "quest_starter": "A rebel in hiding seeks your protection. Why do you help—or betray—them?",
+          "quest_starter": "An Agorean militant believes her collective’s leader is a spy from the Olympus. Why does she trust you to uncover her leader’s true colors? What does this collective fight for?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Rebels are outcasts."
+          "summary": "The Agorean Movement is an independent Faction that questions the queen’s authority and governs part of Santa Maria."
         }
       ],
       "type": "truth"
@@ -13350,36 +13452,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/religion.0",
-          "description": "Vampires are seen as cursed beings, and religious institutions often seek to destroy them.",
+          "description": "The most important practices are held in a cult-like fashion, and the queen and other important figures act as priestesses in these situations. It’s something purely ceremonial, but it reflects the idea that the queen and her peers are more than simple vampires.",
           "oracles": {},
-          "quest_starter": "A priest begins to rally mortals against vampires in Santa Maria. How do you counter their influence?",
+          "quest_starter": "An important ceremony that will happen soon requires half the blood of at least 3 mortals. Why does the queen trust you to collect it?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Religion condemns vampires."
+          "summary": "The government has tones of faith."
         },
         {
           "_id": "truth.option:elegy/religion.1",
-          "description": "Many vampires adhere to faiths that accommodate their existence, blending mortal and vampiric spirituality.",
+          "description": "On the one hand, faith and religion may be ignored by most vampires. On the other hand, they unite many vampires under a large group with its own particular interests. This alternative gives access to the Epitaph Order NPCs.",
           "oracles": {},
-          "quest_starter": "A sacred relic important to vampires is stolen. What role do you play in retrieving it?",
+          "quest_starter": "A local mortal preacher has been saying things that go against the Epitaph Order’s ideals. What commandment do they inspire humans to break? Why do you agree to silence her?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Vampires hold religious beliefs."
+          "summary": "The Epitaph Order is a large and influential religious organization."
         },
         {
           "_id": "truth.option:elegy/religion.2",
-          "description": "Some religious groups secretly include vampires, seeing them as chosen or cursed in alignment with their doctrines.",
+          "description": "A few make prayers and have group meetings, but they have no political influence.",
           "oracles": {},
-          "quest_starter": "A religious sect offers you sanctuary and demands loyalty in return. How do you respond?",
+          "quest_starter": "A vampire who was devoutly religious in life now attends nightly ceremonies associated with her former faith, drawing the curiosity of mortals who sense something’s wrong about her. What’s giving away that she’s not like them? How do you prevent her nature from being discovered by others?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Religion is intertwined with vampirism."
+          "summary": "Almost no undead believes in a bigger power."
         }
       ],
       "type": "truth"
@@ -13405,34 +13507,34 @@
           "_id": "truth.option:elegy/superstitions.0",
           "description": "They are not deterred by crucifixes, garlic, or holy water, and they can enter private domains without invitation. A stake through the heart merely paralyzes them.",
           "oracles": {},
-          "quest_starter": "A suspicious mortal is guarding a place with garlic and crosses. While she is clearly superstitious, she seems to be holding something of importance within said place. What gives it away? How do you get involved in discovering what it is?",
+          "quest_starter": "A suspicious mortal is guarding a place with garlic and crosses. While she is clearly superstitious, she seems to be holding something of importance within said place. What gives it away? How do you get yourself involved in discovering what it is? What is this place?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Most superstitions about vampires are untrue."
+          "summary": "Most of what you heard about vampires is untrue."
         },
         {
           "_id": "truth.option:elegy/superstitions.1",
-          "description": "Garlic, holy water, crucifixes, and other religious symbols are actually harmful. A stake to the heart will kill them, and they cannot enter uninvited.",
+          "description": "They’re not superstitions. Garlic, holy water, crucifixes, and other religious symbols are actually harmful to vampires. A stake to the heart will kill them, and they can’t enter a home or private domain if they’re not invited to. This alternative enables the Superstition optional damage rule in page 40.",
           "oracles": {},
           "quest_starter": "Garlic gas was released in the ventilation system of your progenitor. Who is the culprit? Why does she want to harm your progenitor?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Superstitions about vampires reflect the truth."
+          "summary": "They reflect the real deal."
         },
         {
           "_id": "truth.option:elegy/superstitions.2",
-          "description": "Authentic Faith is a supernatural force rooted in sincere belief. Mortals with Authentic Faith can wield divine symbols to harm vampires.",
+          "description": "Authentic Faith is a supernatural force rooted in sincere, unwavering belief in a higher power, be it a religious deity or a philosophical concept. Mortals with Authentic Faith who wield divine symbols are capable of warding off and even hurting supernatural creatures, particularly vampires. A stake to the heart will paralyze a vampire. This alternative enables the Authentic Faith optional damage rule in page 41.",
           "oracles": {},
-          "quest_starter": "A visiting bishop in Santa Maria plans to bless the water in a large fountain, transforming it into a potent weapon against your kind. How will you stop her? What symbol does she carry?",
+          "quest_starter": "A visiting bishop in Santa Maria plans to bless the water in a large fountain, transforming it into a potent weapon against your kind. How will you stop her, considering she always carries with herself a sacred symbol that can harm you? What symbol is this?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Religious symbols are dangerous in the hands of faithful people."
+          "summary": "Religious symbols are dangerous in the hands of actually faithful people."
         }
       ],
       "type": "truth"
@@ -13456,36 +13558,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/the_internet.0",
-          "description": "Vampires use the internet to communicate, gather information, and maintain the Façade with relative ease.",
+          "description": "In today’s world, no information is truly secure. A single slip, and the Façade will crumble.",
           "oracles": {},
-          "quest_starter": "A hacker has discovered a vampire-only online forum and threatens to expose it. What steps do you take?",
+          "quest_starter": "A ghost hunting YouTube show crew just got actual vampire activity on camera. What did they capture? How will you protect the Façade from them?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "The internet is a useful tool for vampires."
+          "summary": "Using the internet is prohibited by law."
         },
         {
           "_id": "truth.option:elegy/the_internet.1",
-          "description": "The transparency of the digital age has made it harder for vampires to remain hidden, leading to frequent breaches of the Façade.",
+          "description": "As long as you keep your unnatural habits away from social media and use fake accounts, you may use the internet however you want.",
           "oracles": {},
-          "quest_starter": "A viral video appears to capture undeniable evidence of vampiric activity. How do you address the fallout?",
+          "quest_starter": "A couple of young vampires share their unlives openly in social media. Why do you step in to stop them? What’s the last Façade-breaking thing they tweeted?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "The internet poses significant risks."
+          "summary": "Using the internet is permitted."
         },
         {
           "_id": "truth.option:elegy/the_internet.2",
-          "description": "Fearing exposure and surveillance, most vampires steer clear of the digital world, relying on older methods of communication.",
+          "description": "Even though regular internet use is prohibited, the umbernet links all major vampire cities in a secure web, resistant to mortal interference and private. While it doesn’t encompass all the information available on the internet, its functionality is similar.",
           "oracles": {},
-          "quest_starter": "A mortal journalist questions why you are absent from online records. How do you explain this?",
+          "quest_starter": "Sensitive documents of one of your acquaintances were leaked from the umbernet to the internet. How do you intend to investigate this case? What does she promise you in return for your aid in finding the culprit?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Vampires avoid the internet."
+          "summary": "Vampires have their own network, the umbernet."
         }
       ],
       "type": "truth"
@@ -13509,36 +13611,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/werewolves.0",
-          "description": "Vampires and werewolves have an ancient feud, resulting in violent confrontations whenever they meet.",
+          "description": "Werewolves are another type of creature that hides in the night. Vampires and werewolves are not necessarily enemies: sometimes, they cooperate to keep their existences in the shadows. This alternative gives access to the Lycanthrope NPCs.",
           "oracles": {},
-          "quest_starter": "A werewolf pack moves into Santa Maria, threatening your territory. How do you respond?",
+          "quest_starter": "A pack of lycanthropes has taken an interest in a particular place, disrupting the local vampire hierarchy. Why do you involve yourself in this territorial dispute?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Werewolves are mortal enemies of vampires."
+          "summary": "They live in packs within the city and call themselves lycanthropes."
         },
         {
           "_id": "truth.option:elegy/werewolves.1",
-          "description": "While conflicts occur, both sides maintain an uneasy truce to avoid unnecessary bloodshed.",
+          "description": "Beast people are mortals who turn into mindless monsters when the moon is full. Some turn into wolf-people, while others assume forms that resemble cats, rats, bears, etc. They’re never organized. This alternative gives access to the Beast People NPCs.",
           "oracles": {},
-          "quest_starter": "A werewolf requests your help against a common enemy. What do they offer in return?",
+          "quest_starter": "A werecat is terrorizing an area of Santa Maria and bringing unwanted attention from mortals. How will you eliminate this threat?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Werewolves and vampires coexist uneasily."
+          "summary": "Are a subtype of mindless solitary monsters we call beast people."
         },
         {
           "_id": "truth.option:elegy/werewolves.2",
-          "description": "Vampires and werewolves share common goals and often work together, though mistrust lingers.",
+          "description": "They’re almost as numerous as vampires and are organized according to a complex tribal hierarchy. They seek to defend the natural balance of the universe against natural and unnatural threats. Because of that, vampires are their mortal enemies. This alternative gives access to the Varou NPCs.",
           "oracles": {},
-          "quest_starter": "A werewolf ally asks for your help in a dangerous ritual. What risks are involved, and why do you agree?",
+          "quest_starter": "A varou has been killing vampires that wander through a large park. Why do you promise to eliminate it or drive it away? What is your plan?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Werewolves are allies."
+          "summary": "Tribes of werewolves inhabit the wild. They call themselves varou."
         }
       ],
       "type": "truth"
@@ -13562,36 +13664,36 @@
       "options": [
         {
           "_id": "truth.option:elegy/what_mortals_know.0",
-          "description": "Few mortals are aware of the existence of vampires, as the Façade remains strong and well-guarded.",
+          "description": "Having connections with individuals possessing valuable skills or occupying influential positions is advantageous, whether one is undead or not. However, it’s crucial to exercise caution. Before disclosing your true nature, ensure that these individuals have a significant stake in maintaining your secret, that revealing the truth about you won’t be easily believed by others, and that they don’t intend to harm you.",
           "oracles": {},
-          "quest_starter": "A mortal investigator has come dangerously close to uncovering the truth. How do you handle them?",
+          "quest_starter": "A friendly mortal contact begs you to find her child, who has been kidnapped. How will you track down the culprits? Where is she? Do you ask something in return?",
           "roll": {
             "max": 33,
             "min": 1
           },
-          "summary": "Mortals remain blissfully ignorant of vampires."
+          "summary": "While it’s not exactly legal, it’s not uncommon for vampires to have human allies of some sort."
         },
         {
           "_id": "truth.option:elegy/what_mortals_know.1",
-          "description": "Myths, rumors, and conspiracies about vampires persist, and some mortals actively seek to prove their existence.",
+          "description": "While vampires may go unnoticed by the majority, certain secret societies possessing occult knowledge remain vigilant. Among them are black ops agencies dedicated to unveiling the vampiric nature, alongside centuries-old religious circles committed to eradicating every monstrous entity. Investigators, spies, vampire hunters, and paramilitary units pose a tangible threat to the vampire community. This alternative gives access to the Mortal Threats NPCs.",
           "oracles": {},
-          "quest_starter": "A secret society dedicated to hunting vampires is operating in Santa Maria. How do you deal with them?",
+          "quest_starter": "Vampires are being killed in a serial fashion that seems to be the work of a skilled vampire killer. What’s her modus operandi? How do you intend to catch her? What’s in it for you?",
           "roll": {
             "max": 67,
             "min": 34
           },
-          "summary": "Some mortals suspect the truth."
+          "summary": "Secret organizations know vampires exist, and hunters are a threat."
         },
         {
           "_id": "truth.option:elegy/what_mortals_know.2",
-          "description": "Vampires are an open secret, and society has adapted to coexist with them—albeit uneasily.",
+          "description": "Besides mannequins — the human blood bags some vampires have — the Façade requires absolute secrecy and is enforced in a very efficient way. Those who know too much are immediately silenced.",
           "oracles": {},
-          "quest_starter": "A mortal lawmaker proposes harsh restrictions on vampire activities. How do you influence this process?",
+          "quest_starter": "Someone took pictures of you while you were feeding. This could mean a devastating blow to the Façade and a sentence for you. How can you prevent them from causing this damage? Where can you find the photographer? Who is behind all this?",
           "roll": {
             "max": 100,
             "min": 68
           },
-          "summary": "Mortals are aware of vampires."
+          "summary": "Basically no one knows vampires exist."
         }
       ],
       "type": "truth"
@@ -13627,8 +13729,8 @@
         "truth:elegy/religion",
         "truth:elegy/deviance",
         "truth:elegy/werewolves",
-        "truth:elegy/elegies",
-        "truth:elegy/mortal_magic"
+        "truth:elegy/mortal_magic",
+        "truth:elegy/elegies"
       ],
       "type": "world"
     }

--- a/generated-datasworn/manifest.json
+++ b/generated-datasworn/manifest.json
@@ -7,12 +7,8 @@
       "schemaLine": "0.3",
       "packageName": "@datasworn-community/elegy",
       "path": "elegy.json",
-      "description": "Datasworn JSON data for Elegy, a solo roleplaying game of vampires.",
-      "license": "CC-BY-NC-SA-4.0",
-      "dependencies": [
-        "classic",
-        "starforged"
-      ]
+      "description": "Datasworn JSON data for Elegy 3.5, a solo roleplaying game of vampires.",
+      "license": "CC-BY-NC-SA-4.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,22 +3,20 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Datasworn source and generated package artifacts for Elegy.",
+  "description": "Datasworn source and generated package artifacts for Elegy 3.5.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/datasworn-community/datasworn-elegy.git"
   },
   "scripts": {
     "build": "datasworn-build --config datasworn.config.yaml",
-    "validate": "test -f dist/packages/elegy/package.json && test -f dist/packages/elegy/json/elegy.json && test -f generated-datasworn/manifest.json && test -f generated-datasworn/elegy.json"
+    "validate": "test -f dist/packages/elegy/package.json && test -f dist/packages/elegy/json/elegy.json && test -f generated-datasworn/manifest.json && test -f generated-datasworn/elegy.json && node scripts/validate-self-contained.mjs"
   },
   "engines": {
     "bun": ">=1.3"
   },
   "devDependencies": {
     "@datasworn-community/build-tools": "0.3.0",
-    "@datasworn-community/core": "0.3.0",
-    "@datasworn-community/ironsworn-classic": "0.3.0",
-    "@datasworn-community/starforged": "0.3.0"
+    "@datasworn-community/core": "0.3.0"
   }
 }

--- a/scripts/validate-self-contained.mjs
+++ b/scripts/validate-self-contained.mjs
@@ -1,0 +1,155 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const generatedPath = path.join(repositoryRoot, 'generated-datasworn', 'elegy.json')
+const manifestPath = path.join(repositoryRoot, 'generated-datasworn', 'manifest.json')
+const errors = []
+const ids = new Set()
+const references = []
+const nodesByType = new Map()
+const referencePattern =
+  /(?:datasworn:)?([a-z][a-z0-9_.]*):([a-z][a-z0-9_-]*\/[a-z0-9_.*\/-]+)/gi
+
+const readJson = async (filePath) => JSON.parse(await readFile(filePath, 'utf8'))
+
+const hasMatchingId = (referenceId) => {
+  if (!referenceId.includes('*')) return ids.has(referenceId)
+
+  const pattern = referenceId
+    .split('*')
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*')
+  const matcher = new RegExp(`^${pattern}$`)
+  return [...ids].some((id) => matcher.test(id))
+}
+
+const collect = (value, location = '$') => {
+  if (typeof value === 'string') {
+    for (const match of value.matchAll(referencePattern)) {
+      const [, type, target] = match
+      const packageId = target.slice(0, target.indexOf('/'))
+      references.push({ id: `${type}:${target}`, packageId, location })
+    }
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collect(item, `${location}[${index}]`))
+    return
+  }
+
+  if (value === null || typeof value !== 'object') return
+
+  if (Object.hasOwn(value, '_id')) {
+    if (typeof value._id === 'string') ids.add(value._id)
+    else errors.push(`${location}._id is not a string`)
+  }
+
+  if (typeof value.type === 'string') {
+    if (!nodesByType.has(value.type)) nodesByType.set(value.type, [])
+    nodesByType.get(value.type).push({ node: value, location })
+  }
+
+  for (const [key, child] of Object.entries(value)) {
+    const childLocation = `${location}.${key}`
+    collect(child, childLocation)
+  }
+}
+
+const isEmpty = (value) => {
+  if (value === undefined || value === null) return true
+  if (Array.isArray(value)) return value.length === 0
+  if (typeof value === 'object') return Object.keys(value).length === 0
+  return value === ''
+}
+
+const generated = await readJson(generatedPath)
+const manifest = await readJson(manifestPath)
+collect(generated)
+
+if (generated.title !== 'Elegy 3.5') {
+  errors.push(`generated root title must be "Elegy 3.5" (found ${JSON.stringify(generated.title)})`)
+}
+
+for (const [type, expected] of Object.entries({
+  asset: 51,
+  move: 33,
+  oracle_rollable: 32,
+  truth: 13,
+  world: 1
+})) {
+  const actual = nodesByType.get(type)?.length ?? 0
+  if (actual !== expected) errors.push(`expected ${expected} ${type} nodes, found ${actual}`)
+}
+
+for (const { node: oracle, location } of nodesByType.get('oracle_rollable') ?? []) {
+  const diceMatch = /^(\d+)d(\d+)$/.exec(oracle.dice ?? '')
+  if (!diceMatch || Number(diceMatch[1]) !== 1) {
+    errors.push(`${location} has unsupported dice expression ${JSON.stringify(oracle.dice)}`)
+    continue
+  }
+
+  const maximum = Number(diceMatch[2])
+  let expectedMinimum = 1
+  for (const [index, row] of (oracle.rows ?? []).entries()) {
+    const minimum = row.roll?.min
+    const maximumForRow = row.roll?.max
+    if (!Number.isInteger(minimum) || !Number.isInteger(maximumForRow)) {
+      errors.push(`${location}.rows[${index}] has an invalid roll range`)
+      continue
+    }
+    if (minimum !== expectedMinimum || maximumForRow < minimum) {
+      errors.push(
+        `${location}.rows[${index}] expected to begin at ${expectedMinimum}, found ${minimum}-${maximumForRow}`
+      )
+    }
+    expectedMinimum = maximumForRow + 1
+  }
+  if (expectedMinimum !== maximum + 1) {
+    errors.push(`${location} covers 1-${expectedMinimum - 1}; expected 1-${maximum}`)
+  }
+}
+
+for (const { node: world, location } of nodesByType.get('world') ?? []) {
+  const truthIds = (world.truths ?? []).map((entry) =>
+    typeof entry === 'string' ? entry : entry.truth
+  )
+  if (truthIds.length !== 13 || new Set(truthIds).size !== 13) {
+    errors.push(`${location} must contain 13 unique truth references`)
+  }
+}
+
+const externalReferences = new Map()
+for (const reference of references) {
+  if (reference.packageId !== 'elegy') {
+    if (!externalReferences.has(reference.packageId)) externalReferences.set(reference.packageId, [])
+    externalReferences.get(reference.packageId).push(reference)
+  } else if (!hasMatchingId(reference.id)) {
+    errors.push(`unresolved local ID ${reference.id} at ${reference.location}`)
+  }
+}
+
+for (const [packageId, packageReferences] of externalReferences) {
+  const locations = [...new Set(packageReferences.map(({ location }) => location))].join(', ')
+  errors.push(`external Datasworn package ${packageId} referenced at ${locations}`)
+}
+
+const manifestPackage = manifest.packages?.elegy
+for (const [label, value] of [
+  ['manifest.dependencies', manifest.dependencies],
+  ['manifest.publishDependencies', manifest.publishDependencies],
+  ['manifest.packages.elegy.dependencies', manifestPackage?.dependencies],
+  ['manifest.packages.elegy.publishDependencies', manifestPackage?.publishDependencies]
+]) {
+  if (!isEmpty(value)) errors.push(`${label} must be absent or empty`)
+}
+
+if (errors.length > 0) {
+  console.error('Self-containment validation failed:')
+  for (const error of errors) console.error(`- ${error}`)
+  process.exitCode = 1
+} else {
+  console.log(`Self-containment validation passed (${ids.size} IDs, ${references.length} references).`)
+}

--- a/source_data/elegy/assets.yaml
+++ b/source_data/elegy/assets.yaml
@@ -14,7 +14,7 @@ assets:
       name: Elegy Assets
       type: asset_collection
       description: |-
-        __Assets__ represent your abilities, background,skills, traits, and resources. When you create your character, you pick three assets.
+        __Assets__ represent your abilities, background, skills, traits, and resources. When you create your character, you pick three assets.
       contents:
         acute_senses:
           type: asset
@@ -114,9 +114,9 @@ assets:
                 If you drink blood from someone you performed to or who has seen your art, restore full blood.
 
             - text: |-
-                You can find deep meaning within art. When you analyze a work of art, decide what to look for:
-                  * Insight: Roll +intellect and add +1. On a hit, envision what helpful idea it revealed to you, and take +2 focus.
-                  * Comfort: Roll +heart and add +1. On a hit, envision how the experience brought you comfort. Restore +3 spirit.
+                You can find deep meaning within art. When you analyze a work of art, choose your approach:
+                  * Look for insight: Roll +intellect and add +1. On a hit, envision (or ask the oracle for) what helpful truth, concept or idea it revealed to you, and take +2 focus.
+                  * Look for comfort: Roll +heart and add +1. On a hit, envision (or ask the oracle for) what comfort the experience brought to you, and restore +3 spirit.
 
         blood_alchemy:
           type: asset
@@ -251,7 +251,7 @@ assets:
           requirement: None
           abilities:
             - text: |-
-                Your vehicle provides speedy transport. When you drive fast or dangerously, add +1 and take +1 focus on a hit. On a strong hit with a match, take +1 focus.
+                You have a vehicle. When you drive fast or dangerously, add +1 and take +1 focus on a hit. On a strong hit with a match, take +1 focus.
               enabled: true
 
             - text: |-
@@ -473,7 +473,7 @@ assets:
           requirement: None
           abilities:
             - text: |-
-                When you meet a victim in the eyes, you may give it a simple command that will be obeyed instantly (“leave”, “follow”) unless it’s harmful to them or impossible (“die”, “fly”). The victim goes into a trance until right after the action, and won’t recall the incident.
+                When you meet a victim in the eyes, you may give it a simple command that will be obeyed instantly (“leave”, “follow”, “grab”) unless it’s harmful to them or impossible (“die”, “fly”). The victim goes into a trance until right after the action, and won’t recall the incident.
               enabled: true
 
             - text: |-
@@ -537,7 +537,30 @@ assets:
               enabled: true
 
             - text: |-
-                When you conduct extended research or study, re-roll any dice. On a match, you piece together an extraordinary or harrowing new theory; envision the nature 
+                When you conduct extended research or study, re-roll any dice. On a match, you piece together an extraordinary or harrowing new theory; envision the nature of this revelation and take +1 forward if you act on it.
+
+            - text: |-
+                When you recall esoteric knowledge to your advantage, add +1. On a hit, envision the obscure but helpful fact, theory, or technique you put to use, and take +1 focus.
+
+        lunacy:
+          type: asset
+          category: Power
+          _source:
+            <<: &AssetSource
+              <<: *Source
+            page: 13
+          name: Lunacy
+          requirement: None
+          abilities:
+            - text: |-
+                You are able to heighten or dull someone’s current emotions (turn mild irritation into violent rage, or obsession into disinterest).
+              enabled: true
+
+            - text: |-
+                You can disturb someone’s senses with flashes of content of their unconscious that will make them lose touch with reality for one minute.
+
+            - text: |-
+                You can make your victim mistake theirs or others’ identity. For example, you can make someone think they’re Napoleon, or think her wife is secretly an alien in disguise. This effect lasts for one scene.
 
         magnetism:
           type: asset
@@ -574,7 +597,7 @@ assets:
               enabled: true
 
             - text: |-
-                Your mannequin trusts you way more than they should. When you gather info about the mortal world from your mannequin, you may re-roll any dice.
+                Your mannequin trusts you way more than they should. When you gather info about the mortal world by speaking to your mannequin, you may re-roll any dice.
 
             - text: |-
                 Having a steady source of blood brings you peace of mind. When you feed from your mannequin, take +1 spirit on a hit, and +2 spirit on a match.
@@ -733,13 +756,16 @@ assets:
           abilities:
             - text: |-
                 You can sense the intentions of people around you. When you are next to other individuals, you can awaken your powers to ask two of the following questions to the oracle. Then, add +1 and take +1 focus the next move related to the answer.
-                - Who's the most susceptible person in here?
+                - Who's the weakest person in here?
                 - Who's most likely to harm me?
                 - Who's most likely to give me what I want?
               enabled: true
 
             - text: |-
-                You can read people’s thoughts and memories. Once per night, you may psychically inspect the mind of someone next to you as if it were a book. When you hold an object in your hands, you are able to pick up psychic impressions from it and learn who held it last and when it was last held.
+                You can read people’s thoughts and memories. Once per night, you may psychically inspect the mind of someone next to you as if it were a book.
+
+            - text: |-
+                When you hold an object in your hands, you are able to pick up psychic impressions from it and learn who held it last and when it was last held.
 
         stalker:
           type: asset
@@ -836,7 +862,7 @@ assets:
               enabled: true
 
             - text: |-
-                In some ways, time brought you closer to the mortals around you. Whenever you communicate with or read the emotions of humans, add +1 and take +1 focus on a hit.
+                In some ways, time brought you even closer to your late humanity and to the mortals around you. Whenever you communicate with or read the emotions of humans, add +1 and take +1 focus on a hit.
 
             - text: |-
                 Your experience with your distinct nature shaped your presence differently than other vampires. Whenever you hide your vampiric nature from other vampires or even mortals, re-roll any dice.
@@ -931,16 +957,18 @@ assets:
             page: 16
           name: Path of the Guardian
           requirement: None
+          description: |-
+            If you possess more than one point of this asset, you can choose to repel only certain types of creatures. For instance, even with points 1 and 2, you can opt to repel only supernatural living creatures if desired.
           abilities:
             - text: |-
                 When you draw a circle in blood and chant magic words, the area will magically repel mortals and animals.
               enabled: true
 
             - text: |-
-                When you possess more than one point of this asset, you can choose to repel only certain types of creatures. For instance, even with points 1 and 2, you can opt to repel only supernatural living creatures if desired.
+                When you draw a circle in blood and chant magic words, the area will magically repel supernatural living creatures.
 
             - text: |-
-                You can repel vampires and the undead.
+                When you draw a circle in blood and chant magic words, the area will magically repel vampires and the undead.
 
         path_of_the_pursuer:
           type: asset
@@ -993,14 +1021,14 @@ assets:
           requirement: None
           abilities:
             - text: |-
-                When you wash your face in blood and speak the name of a victim, she will experience intense hunger. A vampire will be induced to starvation, and will act out of hunger.
+                When you wash your face in blood and speak the name of a victim, she will experience intense hunger. A vampire will be induced to starvation, and will act out of instinct, impulse and hunger.
               enabled: true
 
             - text: |-
                 When you burn a piece of paper marked with your bloody hand print and say the name of a vampire within a one-kilometer radius, the victim will lose the reanimating power of blood and turn into a corpse for a whole night.
 
             - text: |-
-                This ceremony is only potent against living entities. By burning a strand of hair, or any other refuse from the subject’s body, and uttering mystical incantations, a curse is placed that you can activate at will. When you do, the victim’s throat splits, and their bowels forcefully expel from their body, leading to almost certain death, even with immediate medical intervention.
+                This ceremony is only potent against living entities. By burning a strand of hair, a nail clipping, or any other refuse from the subject’s body, and uttering mystical incantations, a curse is placed that you can activate at will. When you do, the victim’s throat splits, and their bowels forcefully expel from their body, leading to almost certain death, even with immediate medical intervention.
 
         path_of_the_tongue:
           type: asset

--- a/source_data/elegy/moves.yaml
+++ b/source_data/elegy/moves.yaml
@@ -60,16 +60,16 @@ moves:
             - With charm, composure, or manipulation: Roll +glamour.
             - With expertise, focus, or observation: Roll +intellect.
           On a __strong hit__, you are successful. Take +1 focus.
-          On a __weak hit__, you succeed but at a cost. Take +1 focus and  [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
-          On a __miss__, you fail or suffer a dire consequence. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+          On a __weak hit__, you succeed, but not without a cost. Take +1 focus and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+          On a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
         outcomes:
           strong_hit:
             text: On a __strong hit__, you are successful. Take +1 focus.
           weak_hit:
             text: |-
-              On a __weak hit__, you succeed but at a cost. Take +1 focus and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+              On a __weak hit__, you succeed, but not without a cost. Take +1 focus and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
           miss:
-            text: On a __miss__, you fail or suffer a dire consequence. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+            text: On a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
 
       secure_an_advantage:
         name: Secure an Advantage
@@ -113,7 +113,7 @@ moves:
             - With aggression, strength, or toughness: Roll +force.
             - With charm, composure, or manipulation: Roll +glamour.
             - With expertise, focus, or observation: Roll +intellect.
-          On a __strong hit__, take both benefits:
+          On a hit, you succeed. On a __strong hit__, take both benefits:
             - Take +2 focus.
             - Add +1 on your next roll (not a Conclusion move).
           On a __weak hit__, take one benefit:
@@ -121,9 +121,15 @@ moves:
           On a __miss__, you fail or your assumptions betray you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
         outcomes:
           strong_hit:
-            text: "On a __strong hit__, Take both benefits: +2 focus and +1 on your next roll."
+            text: |-
+              On a hit, you succeed. On a __strong hit__, take both benefits:
+              - Take +2 focus.
+              - Add +1 on your next roll (not a Conclusion move).
           weak_hit:
-            text: "On a __weak hit__, Take one benefit: +2 focus or +1 on your next roll."
+            text: |-
+              On a __weak hit__, choose one:
+              - Take +2 focus.
+              - Add +1 on your next roll (not a Conclusion move).
           miss:
             text: "On a __miss__, you fail or your assumptions betray you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)."
 
@@ -132,7 +138,7 @@ moves:
         type: move
         roll_type: action_roll
         trigger:
-          text: When you search for clues, conduct an investigation, or analyze evidence...
+          text: When you search for clues, conduct an investigation, analyze evidence, or do research...
           conditions:
             - method: player_choice
               roll_options:
@@ -140,31 +146,31 @@ moves:
                   stat: intellect
         _source:
           <<: *Source
-          page: 4
+          page: 3
         text: |-
-          When you search for clues, conduct an investigation, or analyze evidence, roll +intellect. If you act within a community or ask questions of someone you share a bond with, add +1.
-          On a __strong hit__, you discover something helpful and specific. Envision what you learn, and take +2 focus.
-          On a __weak hit__, you discover something that complicates your quest or introduces new danger. Take +1 focus.
-          On a __miss__, you unearth a dire threat or an unwelcome truth that undermines your quest. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+          When you search for clues, conduct an investigation, analyze evidence, or do research, roll +intellect.
+          On a __strong hit__, you discover something helpful and specific. The path you must follow or action you must take to make progress is made clear. Envision what you learn. Then, take +2 focus.
+          On a __weak hit__, the information provides new insight, but also complicates your quest. Envision what you discover. Then, take +1 focus.
+          On a __miss__, your investigation unearths a dire threat or reveals an unwelcome truth that undermines your quest. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
         outcomes:
           strong_hit:
-            text: On a __strong hit__, You discover something helpful and specific. Take +2 focus.
+            text: On a __strong hit__, you discover something helpful and specific. The path you must follow or action you must take to make progress is made clear. Envision what you learn. Then, take +2 focus.
           weak_hit:
-            text: On a __weak hit__, You discover something that complicates your quest or introduces danger. Take +1 focus.
+            text: On a __weak hit__, the information provides new insight, but also complicates your quest. Envision what you discover. Then, take +1 focus.
           miss:
-            text: On a __miss__, you unearth a dire threat or unwelcome truth. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+            text: On a __miss__, your investigation unearths a dire threat or reveals an unwelcome truth that undermines your quest. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
 
       aid_your_ally:
         name: Aid Your Ally
         type: move
         roll_type: no_roll
         trigger:
-          text: When you Secure an Advantage in direct support of an ally...
+          text: When you [Secure an Advantage](datasworn:move:elegy/adventure/secure_an_advantage) in direct support of an ally...
         _source:
           <<: *Source
-          page: 4
+          page: 3
         text: |-
-          When you Secure an Advantage in direct support of an ally and score a hit, they (instead of you) can take the benefits of the move. If you are in combat and score a strong hit, you and your ally have initiative.
+          When you [Secure an Advantage](datasworn:move:elegy/adventure/secure_an_advantage) in direct support of an ally and score a hit, they (instead of you) can take the benefits of the move. If you are in combat and score a strong hit, you and your ally have initiative.
     
       compel:
         name: Compel
@@ -190,7 +196,7 @@ moves:
                   stat: heart
         _source:
           <<: *Source
-          page: 5
+          page: 3
         text: |-
           When you try to persuade someone or make them an offer, envision your approach. If you...
             - Charm or lie: Roll +glamour.
@@ -246,7 +252,7 @@ moves:
                   stat: glamour
         _source:
           <<: *Source
-          page: 5
+          page: 4
         text: |-
           When you use your supernatural abilities to activate a power, visualize the effects you want to manifest and roll the stat indicated in its asset card. If you use them to appear human for a scene (blushing, being able to have sex or consume food), roll +Glamour.
           On a __strong hit__, the power is activated successfully. Take +1 focus.
@@ -273,12 +279,16 @@ moves:
                   stat: intellect
         _source:
           <<: *Source
-          page: 6
+          page: 4
         text: |-
+          To decide if you want to include rituals in your setting, see the Rituals Truths.
+
           When you perform a ritual of blood magic, envision what you want to achieve and how you perform it. Then, roll +Intellect.
           - On a __strong hit__, the ritual is performed successfully. Take +1 focus.
           - On a __weak hit__, the ritual is performed successfully, but it consumes the blood within you. Spend 1 blood.
-          - On a __miss__, the ritual consumes your blood and has undesired consequences. Spend 1 blood and roll: \n {{table>move.oracle_rollable:elegy/adventure/perform_ritual.perform_ritual}}
+          - On a __miss__, the ritual consumes your blood and has undesired consequences. Spend 1 blood and roll on the list below:
+
+            {{table>move.oracle_rollable:elegy/adventure/perform_ritual.perform_ritual}}
             - 1-20: The ritual has the opposite effect.
             - 21-40: It attracts mortal attention.
             - 41-60: It affects a different target.
@@ -324,7 +334,7 @@ moves:
                   stat: intellect
         _source:
           <<: *Source
-          page: 6
+          page: 4
         text: |-
           When you spend the whole daytime in deep sleep in a dark place, roll +heart or +intellect, whichever is higher. By default, you need the Lair asset to have access to a secure place to sleep you can call yours. If you don’t have it, you must sleep in abandoned places.
           On a __strong hit__, you rest well, and gain both of the following benefits:
@@ -332,7 +342,7 @@ moves:
           - Gain +2 focus
           On a __weak hit__, you rest with only partial success. You gain only one of the benefits:
           - Restore 1 health or Gain +2 focus.
-          On a __miss__, choose one of the following:
+          On a __miss__, pick one of the options below. On a match, pick both:
           - You get hungrier: Lose 1 blood
           - You don't sleep well: Lose 1 focus
         outcomes:
@@ -341,7 +351,7 @@ moves:
           weak_hit:
             text: "On a __weak hit__, you rest well but only gain one bonus: Restore 1 health or Gain +2 focus."
           miss:
-            text: "On a __miss__, you pick one of the following: You get hungrier and lose 1 blood, or you don't sleep well and lose 1 focus."
+            text: "On a __miss__, pick one of the options below. On a match, pick both: You get hungrier and lose 1 blood, or you don't sleep well and lose 1 focus."
 
       advance:
         name: Advance
@@ -351,7 +361,7 @@ moves:
           text: When you focus on your skills, receive training, find inspiration, or earn a reward...
         _source:
           <<: *Source
-          page: 6
+          page: 5
         text: |-
           When you focus on your skills, receive training, find inspiration, or earn a reward, you may spend:
           - 3 XP to add a new asset, or
@@ -366,14 +376,13 @@ moves:
         trigger:
           text: When you spend a few seconds in place and use your supernatural abilities to heal yourself...
           conditions:
-            - text: With your supernatural abilities to heal
-              method: player_choice
+            - method: player_choice
               roll_options:
                 - using: stat
                   stat: force
         _source:
           <<: *Source
-          page: 7
+          page: 5
         text: |-
           When you spend a few seconds in place and use your supernatural abilities to heal yourself, roll +force. 
           - On a __strong hit__, the care is helpful. If you are wounded, clear the impact and take or give +2 health. Otherwise, take +3 health. Spend 1 blood.
@@ -403,7 +412,7 @@ moves:
                   stat: heart
         _source:
           <<: *Source
-        page: 5
+          page: 5
         text: |-
           When you socialize, share intimacy, or find a moment of peace, roll +heart.
           - On a __strong hit__, you find companionship or comfort and your spirit is strengthened. If you are shaken, clear the impact and take +1 spirit. Otherwise, take +2 spirit.
@@ -446,7 +455,7 @@ moves:
                   stat: heart
         _source:
           <<: *Source
-          page: 9
+          page: 5
         text: |-
           When you attempt to drink blood from a living being, envision the scene. 
           - If you act with brutality and physically overwhelm your struggling victim, roll +force.
@@ -518,8 +527,14 @@ moves:
               - roll: { min: 91, max: 100 }
                 text: 'Yes'
         _source:
-          <<: *Source
-          page: 107
+          <<: &RulebookSource
+            title: 'Elegy 3.5'
+            license: https://creativecommons.org/licenses/by-nc-sa/4.0
+            url: https://miraclem.itch.io/elegy
+            date: 2024-07-31
+            authors:
+              - name: moro de oliveira
+          page: 42
         roll_type: no_roll
         trigger:
           text: When you seek to resolve questions, discover details in the world, determine how other characters respond, or trigger encounters or events...
@@ -557,11 +572,11 @@ moves:
           text: When you suffer the outcome of an action...
         _source:
           <<: *Source
-          page: 7
+          page: 11
         text: |-
           When you suffer the outcome of an action, choose one:
           - Make the most obvious negative outcome happen.
-          - Ask the oracle for inspiration. Interpret the answer as a hardship or complication appropriate to the situation.
+          - [Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) for inspiration. Interpret the answer as a hardship or complication appropriate to the situation.
           - Roll on the list below. If the result doesn’t fit the situation, roll again.
          
           {{table>move.oracle_rollable:elegy/suffer/pay_the_price.pay_the_price}}
@@ -621,11 +636,11 @@ moves:
           text: When your focus is at its minimum (-6), and you suffer additional -focus...
         _source:
           <<: *Source
-          page: 9
+          page: 11
         text: |-
           When your focus is at its minimum (-6), and you suffer additional -focus, choose one:
           - Exchange each additional -focus for any combination of -health, -spirit, or -blood as appropriate to the circumstances.
-          - Envision an event or discovery (ask the oracle if unsure) which undermines your progress in a current quest, journey, or fight. Then, for each additional -focus, clear 1 unit of progress on that track per its rank:
+          - Envision an event or discovery ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure) which undermines your progress in a current quest, journey, or fight. Then, for each additional -focus, clear 1 unit of progress on that track per its rank:
             - Troublesome = clear 3 progress
             - Dangerous = clear 2 progress
             - Formidable = clear 1 progress
@@ -645,7 +660,7 @@ moves:
                   stat: force
         _source:
           <<: *Source
-          page: 9
+          page: 12
         text: |-
           When you face physical damage, suffer -health equal to your foe’s rank or as appropriate to the situation. If your health is 0, suffer -focus equal to any remaining -health. Then, roll +Force.
           
@@ -678,7 +693,7 @@ moves:
               - roll: { min: 1, max: 10 }
                 text: 'The harm is mortal. [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
               - roll: { min: 11, max: 25 }
-                text: 'You are on the brink of your last death. You need to Heal within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
+                text: 'You are on the brink of your last death. You need to [Heal](datasworn:move:elegy/adventure/heal) within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
               - roll: { min: 26, max: 50 }
                 text: 'You are unconscious and out of action. If left alone, you come back to your senses in an hour or two. If you are vulnerable to a foe not inclined to show mercy, [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
               - roll: { min: 51, max: 100 }
@@ -698,7 +713,7 @@ moves:
                 stat: heart
         _source:
           <<: *Source
-          page: 10
+          page: 12
         text: |-
           When you are brought to the brink of your annihilation, and glimpse the world beyond, roll +Heart.
           
@@ -706,7 +721,7 @@ moves:
           
           - On a __weak hit__, choose one:
             - You die, but not before making a noble sacrifice. Envision your final moments.
-            - Death desires something of you in exchange for your unlife. Envision what it wants (ask the oracle if unsure), and Sing an Elegy (formidable or extreme) to complete that quest. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest.
+            - Death desires something of you in exchange for your unlife. Envision what it wants ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to complete that quest. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest.
           
           - On a __miss__, you are destroyed.
         outcomes:
@@ -716,7 +731,7 @@ moves:
             text: |-
               On a __weak hit__, choose one:
               - You die, but not before making a noble sacrifice. Envision your final moments.
-              - Death desires something of you in exchange for your unlife. Envision what it wants (ask the oracle if unsure), and Sing an Elegy (formidable or extreme) to complete that quest. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest.
+              - Death desires something of you in exchange for your unlife. Envision what it wants ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to complete that quest. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are dead. Otherwise, you return to the mortal world and are now cursed. You may only clear the cursed debility by completing the quest.
           miss:
             text: On a __miss__, you are destroyed.
       
@@ -734,7 +749,7 @@ moves:
                   stat: intellect
         _source:
           <<: *Source
-          page: 9
+          page: 13
         text: |-
           When you use supernatural powers or spend blood as a result of the [Pay the Price](datasworn:move:elegy/suffer/pay_the_price) move, suffer -blood as appropriate to the situation. If your blood is 0, suffer -focus equal to any remaining -focus. Then, roll +Intellect.
 
@@ -767,7 +782,7 @@ moves:
               - roll: { min: 1, max: 10 }
                 text: 'Your hunger consumes you. [Face Starvation](datasworn:move:elegy/suffer/face_starvation).'
               - roll: { min: 11, max: 25 }
-                text: 'You are on the brink of starvation. You need to Feed within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
+                text: 'You are on the brink of starvation. You need to [Feed](datasworn:move:elegy/adventure/feed) within an hour or two, or [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
               - roll: { min: 26, max: 50 }
                 text: 'You are unconscious and out of action. If left alone, you come back to your senses in an hour or two. If you are vulnerable to a foe not inclined to show mercy, [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
               - roll: { min: 51, max: 100 }
@@ -787,7 +802,7 @@ moves:
                   stat: intellect
         _source:
           <<: *Source
-          page: 10
+          page: 13
         text: |-
           When you are brought to the brink of starvation, roll +Intellect.
           
@@ -795,9 +810,9 @@ moves:
           
           - On a __weak hit__, choose one:
             - Your humanity is devoured, but not before remembering a moment of your mortal life. Envision what flashes behind your eyes.
-            - You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and Sing an Elegy to her (formidable or extreme).
+            - You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to her (formidable or extreme).
           
-          - On a __miss__, your hunger destroys your humanity and...
+          - On a __miss__, your hunger destroys your humanity and you are forever a mindless beast.
 
         outcomes:
           strong_hit:
@@ -806,9 +821,9 @@ moves:
             text: |-
               On a __weak hit__, choose one:
               - Your humanity is devoured, but not before remembering a moment of your mortal life. Envision what flashes behind your eyes.
-              - You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and Sing an Elegy to her (formidable or extreme).
+              - You get so frenzied, you commit something that angers your ruler. Envision what it is. She’ll ask something in return for letting you live. When she does, envision the frightening encounter and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to her (formidable or extreme).
           miss:
-            text: On a __miss__, your hunger destroys your humanity and...
+            text: On a __miss__, your hunger destroys your humanity and you are forever a mindless beast.
       
       endure_stress:
         name: Endure Stress
@@ -823,7 +838,7 @@ moves:
                   stat: heart
         _source:
           <<: *Source
-          page: 9
+          page: 14
         text: |-
           When you face mental shock or despair, suffer -spirit equal to your foe’s rank or as appropriate to the situation (see Stress). If your spirit is 0, suffer -focus equal to any remaining -spirit. Then, roll +Heart.
           
@@ -833,7 +848,7 @@ moves:
           
           - On a __weak hit__, you press on.
           
-          - On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the following table:
+          - On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the following table:
 
           {{table>move.oracle_rollable:elegy/suffer/endure_stress.endure_stress}}
 
@@ -847,7 +862,7 @@ moves:
             text: On a __weak hit__, you press on.
           miss:
             text: |-
-              On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the list below.
+              On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the list below.
         oracles:
           endure_stress:
             name: Endure Stress Consequences
@@ -857,7 +872,7 @@ moves:
               - roll: { min: 1, max: 10 }
                 text: 'You are overwhelmed. [Face Desolation](datasworn:move:elegy/suffer/face_desolation).'
               - roll: { min: 11, max: 25 }
-                text: 'You give up. Forsake Your Elegy (if possible, one relevant to your current crisis).'
+                text: 'You give up. [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy) (if possible, one relevant to your current crisis).'
               - roll: { min: 26, max: 50 }
                 text: 'You are unconscious and out of action. If left alone, you come back to your senses in an hour or two. If you are vulnerable to a foe not inclined to show mercy, [Face Last Death](datasworn:move:elegy/suffer/face_last_death).'
               - roll: { min: 51, max: 100 }
@@ -876,7 +891,7 @@ moves:
                   stat: heart
         _source:
           <<: *Source
-          page: 10
+          page: 14
         text: |-
           When you are brought to the brink of desolation, roll +Heart.
 
@@ -884,7 +899,7 @@ moves:
 
           - On a __weak hit__, choose one:
             - Your spirit or sanity breaks, but not before you make a noble sacrifice. Envision your final moments.
-            - You see a vision of a dreaded event coming to pass. Envision that dark future, and Sing an Elegy (formidable or extreme) to prevent it. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest.
+            - You see a vision of a dreaded event coming to pass. Envision that dark future ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to prevent it. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest.
 
           - On a __miss__, you succumb to despair or horror and are lost.
           
@@ -895,7 +910,7 @@ moves:
             text: |-
               On a __weak hit__, choose one:
               - Your spirit or sanity breaks, but not before you make a noble sacrifice. Envision your final moments.
-              - You see a vision of a dreaded event coming to pass. Envision that dark future, and Sing an Elegy (formidable or extreme) to prevent it. If you fail to score a hit when you Sing an Elegy, or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest.
+              - You see a vision of a dreaded event coming to pass. Envision that dark future ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or extreme) to prevent it. If you fail to score a hit when you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy), or refuse the quest, you are lost. Otherwise, you return to your senses and are now tormented. You may only clear the tormented debility by completing the quest.
           miss:
             text: On a __miss__, you succumb to despair or horror and are lost.
   connection:
@@ -903,7 +918,7 @@ moves:
     type: move_category
     _source:
       <<: *Source
-      page: 11
+      page: 9
     summary:  When you interact with other characters ...
     contents:
       make_connection:
@@ -919,7 +934,7 @@ moves:
                   stat: heart
         _source:
           <<: *Source
-          page: 10
+          page: 9
         text: |-
           When you search out a new relationship or give focus to an existing relationship (not an ally or companion), roll +Heart.
 
@@ -927,7 +942,7 @@ moves:
 
           - On a __weak hit__, as above, but this connection comes with a complication or cost. Envision what they reveal or demand.
 
-          - On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)..
+          - On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
 
         outcomes:
           strong_hit:
@@ -935,7 +950,7 @@ moves:
           weak_hit:
             text: On a __weak hit__, as above, but this connection comes with a complication or cost. Envision what they reveal or demand.
           miss:
-            text: On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price)..
+            text: On a __miss__, you don’t make a connection and the situation worsens. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
       develop_relationship:
         name: Develop a Relationship
         type: move
@@ -944,7 +959,7 @@ moves:
           text: When a relationship with a connection is reinforced by...
         _source:
           <<: *Source
-          page: 10
+          page: 9
         text: |-
           When a relationship with a connection is reinforced by...
           - accomplishing a mission that benefits them
@@ -952,7 +967,7 @@ moves:
           - presenting them with a valuable gift
           - sharing a significant moment
           - standing by them in times of hardship
-          - successfully navigating a test of your relationship
+          - successfully navigating a [Test Your Relationship](datasworn:move:elegy/connection/test_your_relationship)
           ...mark progress according to the rank of the connection.
       test_your_relationship:
         name: Test Your Relationship
@@ -967,7 +982,7 @@ moves:
                   stat: heart
         _source:
           <<: *Source
-          page: 11
+          page: 9
         text: |-
           When your relationship with a connection is tested through conflict, betrayal, or circumstance, roll +Heart. If you share a bond, add +1.
 
@@ -975,15 +990,18 @@ moves:
           - On a __weak hit__, mark progress, but also envision a demand or complication as a fallout of this test.
           - On a __miss__, or if you have no interest in maintaining this relationship, choose one:
             - Lose the connection: Envision how this impacts you and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
-            - Prove your loyalty: Envision what you offer or what they demand, and Sing an Elegy (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone.
+            - Prove your loyalty: Envision what you offer or what they demand, and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone.
 
         outcomes:
           strong_hit:
-            text: On a __strong hit__, mark progress. Your bond is strengthened, and the relationship endures.
+            text: On a __strong hit__, mark progress.
           weak_hit:
-            text: On a __weak hit__, mark progress, but envision a complication or demand that arises as a result of this test. The relationship is strained or has a cost.
+            text: On a __weak hit__, mark progress, but also envision a demand or complication as a fallout of this test.
           miss:
-            text: "On a __miss__, or if you have no interest in maintaining the relationship, choose one: \n - Lose the connection: Envision how this impacts you and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price). \n - Prove your loyalty: Envision what you offer or what they demand, and Sing an Elegy (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone."
+            text: |-
+              On a __miss__, or if you have no interest in maintaining this relationship, choose one:
+              - Lose the connection: Envision how this impacts you and [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+              - Prove your loyalty: Envision what you offer or what they demand, and [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) (formidable or greater) to see it done. Until you finish it, take no benefit for the connection. If you refuse or fail, the connection is permanently undone.
       form_a_bond:
         name: Form a Bond
         type: move
@@ -997,9 +1015,9 @@ moves:
                 - using: progress_track     
         _source:
           <<: *Source
-          page: 12
+          page: 10
         text: |-
-          When your connection with someone is ready to evolve, roll the challenge dice and compare the result with your progress.
+          Conclusion move. When your connection with someone is ready to evolve, roll the challenge dice and compare the result with your progress.
 
           - On a __strong hit__, a bond is established. Earn XP based on the connection’s rank:
             - Troublesome = 1 tick
@@ -1010,24 +1028,32 @@ moves:
 
             This reward extends to all allies tied to this connection. When a character you’re bonded to supports you in a move closely related to their role, add +2 instead of +1, and take +1 focus.
 
-          - On a __weak hit__, follow the same steps as above, but your connection seeks something more first. To form the bond and earn the XP reward, envision the request and fulfill it (or Sing an Elegy to guarantee its completion).
+          - On a __weak hit__, follow the same steps as above, but your connection seeks something more first. To form the bond and earn the XP reward, envision the request and fulfill it (or [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to guarantee its completion).
 
           - On a __miss__, they reveal a motivation or background that introduces tension. If you decide to maintain this relationship, roll both challenge dice, take the lower value, and clear that number of progress boxes. Then, increase the connection’s rank by one (if not already epic).
 
         outcomes:
           strong_hit:
-            text: On a __strong hit__, a bond is established. Earn XP based on the connection's rank. This reward extends to all allies tied to this connection. When bonded allies support you in a move related to their role, add +2 instead of +1, and take +1 focus.
+            text: |-
+              On a __strong hit__, a bond is established. Earn XP based on the connection’s rank:
+              - Troublesome = 1 tick
+              - Dangerous = 2 ticks
+              - Formidable = 1 box
+              - Extreme = 2 boxes
+              - Epic = 3 boxes
+
+              This reward extends to all allies tied to this connection. When a character you’re bonded to supports you in a move closely related to their role, add +2 instead of +1, and take +1 focus.
           weak_hit:
-            text: On a __weak hit__, follow the same steps as above, but your connection seeks something more first. Envision what they request and fulfill it, or Sing an Elegy to guarantee its completion.
+            text: On a __weak hit__, follow the same steps as above, but your connection seeks something more first. To form the bond and earn the XP reward, envision the request and fulfill it (or [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to guarantee its completion).
           miss:
-            text: On a __miss__, the connection reveals a motivation or background that introduces tension. If you wish to continue the relationship, roll both challenge dice, take the lower value, and clear that number of progress boxes. Then, increase the connection’s rank by one (if not already epic).
+            text: On a __miss__, they reveal a motivation or background that introduces tension. If you decide to maintain this relationship, roll both challenge dice, take the lower value, and clear that number of progress boxes. Then, increase the connection’s rank by one (if not already epic).
 
   quest:
     name: Quest Moves
     type: move_category
     _source:
       <<: *Source
-      page: 11
+      page: 6
     summary:  When you swear or complete quests / elegies ...
     contents:
       sing_an_elegy:
@@ -1043,7 +1069,7 @@ moves:
                 stat: heart
         _source:
           <<: *Source
-          page: 15
+          page: 6
         text: |-
           When you swear to complete a quest, write your elegy and give it a rank. Then, roll +Heart. If you make this promise to a connection, add +1; if you share a bond, add +2.
 
@@ -1069,7 +1095,7 @@ moves:
           text: When you make significant progress in your quest ...
         _source:
           <<: *Source
-          page: 16
+          page: 6
         text: |-
           When you make significant progress in your quest by overcoming a critical obstacle, solving a complex mystery, defeating a powerful threat, gaining vital support, or acquiring a crucial item, you may mark progress.
 
@@ -1091,42 +1117,30 @@ moves:
               - roll_options:
                   - using: progress_track
           text: |-
-            __When you achieve what you believe to be the fulfillment of your promise__, roll the challenge dice and compare to your progress.
+            __Conclusion move.__ When you achieve what you believe to be the fulfillment of your promise, roll the challenge dice and compare to your progress. Focus is ignored on this roll.
 
-            On a __strong hit__, your quest is complete. Mark a reward on your quest's legacy track per the quest's rank:
-              - Troublesome: 1 tick
-              - Dangerous: 2 ticks
-              - Formidable: 1 box
-              - Extreme: 2 boxes
-              - Epic: 3 boxes.
-            Any allies who shared this vow also mark the reward.
+            On a __strong hit__, your quest is complete. Mark experience (troublesome=1; dangerous=2; formidable=3; extreme=4; epic=5).
 
-            On a __weak hit__, as above, but there is more to be done or you realize the truth of your quest. Envision what you discover (ask the oracle if unsure). If you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right, take your full legacy reward. Otherwise, mark the reward one rank lower.
+            On a __weak hit__, there is more to be done, or you realize the truth of your quest. Envision what you discover ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure). Then, mark experience (troublesome=0; dangerous=1; formidable=2; extreme=3; epic=4). You may [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right. If you do, add +1.
 
-            On a __miss__, your quest is undone through an unexpected complication or realization. Envision what happens and choose one:
-              * Give up on the quest: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy).
-              * Recommit to the quest: Roll both challenge dice, take the lowest value, and clear that number of progress boxes. Then, raise the quest's rank by one (if not already epic).
+            On a __miss__, your quest is undone. Envision what happens ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and choose one:
+              * You recommit: Clear all but one filled progress, and raise the quest’s rank by one (if not already epic).
+              * You give up: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy).
           outcomes:
             strong_hit:
               text: |-
-                On a __strong hit__, your quest is complete. Mark a reward on your quest's legacy track per the quest's rank:
-                  - Troublesome: 1 tick
-                  - Dangerous: 2 ticks
-                  - Formidable: 1 box
-                  - Extreme: 2 boxes
-                  - Epic: 3 boxes.
-                Any allies who shared this vow also mark the reward.
+                On a __strong hit__, your quest is complete. Mark experience (troublesome=1; dangerous=2; formidable=3; extreme=4; epic=5).
             weak_hit:
               text: |-
-                On a __weak hit__, your quest is fulfilled, but there is more to be done or you realize the truth of your quest. If you [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right, take your full legacy reward per the quest's rank. Otherwise, make the reward one rank lower. Any allies who shared this vow also mark the reward.
+                On a __weak hit__, there is more to be done, or you realize the truth of your quest. Envision what you discover ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure). Then, mark experience (troublesome=0; dangerous=1; formidable=2; extreme=3; epic=4). You may [Sing an Elegy](datasworn:move:elegy/quest/sing_an_elegy) to set things right. If you do, add +1.
             miss:
               text: |-
-                On a __miss__, your quest is undone through an unexpected complication or realization. Envision what happens and choose one:
-                  * Give up on the quest: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy).
-                  * Recommit to the quest: Roll both challenge dice, take the lowest value, and clear that number of progress boxes. Then, raise the quest's rank by one (if not already epic).
+                On a __miss__, your quest is undone. Envision what happens ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure), and choose one:
+                  * You recommit: Clear all but one filled progress, and raise the quest’s rank by one (if not already epic).
+                  * You give up: [Forsake Your Elegy](datasworn:move:elegy/quest/forsake_your_elegy).
           _source:
             <<: *Source
-            page: 17
+            page: 6
 
       forsake_your_elegy:
           name: Forsake Your Elegy
@@ -1139,7 +1153,7 @@ moves:
 
             Then, envision the impact of this failure and choose one or more as appropriate to the nature of the elegy. Any allies who shared this vow may also envision a cost.
 
-              * You are demoralized or dispirited: [Endure Stress](datasworn:move:elegy/suffer/endure_stress).
+              * You are demoralized or dispirited: Lose spirit according to the situation (see Stress).
               * A connection loses faith: [Test Your Relationship](datasworn:move:elegy/connection/test_your_relationship) when you next interact.
               * Your supernatural abilities weaken drastically: Discard a power asset.
               * You must abandon a path or resource: Discard an asset (not a power or nature one).
@@ -1148,7 +1162,7 @@ moves:
               * Your reputation suffers: Envision how this failure marks you.
           _source:
             <<: *Source
-            page: 160
+            page: 7
 
   combat:
     name: Combat Moves
@@ -1216,16 +1230,16 @@ moves:
           __When you fight against a foe at close quarters or exchange fire at a distance__, roll +Force if you are in close combat, or roll +Dexterity if you are exchanging fire.
 
           - On a __strong hit__, mark progress twice. You overwhelm your foe.
-          - On a __weak hit__, mark progress, but you are dealt a counterblow or setback. Pay the Price.
-          - On a __miss__, your foe dominates this exchange. Pay the Price.
+          - On a __weak hit__, mark progress, but you are dealt a counterblow or setback. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+          - On a __miss__, your foe dominates this exchange. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
 
         outcomes:
           strong_hit:
             text: On a __strong hit__, mark progress twice. You overwhelm your foe.
           weak_hit:
-            text: On a __weak hit__, mark progress, but you are dealt a counterblow or setback. Pay the Price.
+            text: On a __weak hit__, mark progress, but you are dealt a counterblow or setback. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
           miss:
-            text: On a __miss__, your foe dominates this exchange. Pay the Price.
+            text: On a __miss__, your foe dominates this exchange. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
         _source:
           <<: *Source
           page: 8
@@ -1236,27 +1250,27 @@ moves:
           tracks:
             category: Combat
           trigger:
-            text: When you take decisive action to end the fight...
+            text: When you take decisive action...
             conditions:
               - roll_options:
                   - using: progress_track
           text: |-
-            __When you take decisive action to end the fight__, roll the challenge dice and compare to your progress. Focus is ignored on this roll.
+            __Conclusion move.__ When you take decisive action, roll the challenge dice and compare to your progress. Focus is ignored on this roll.
 
-            On a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent.
+            On a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure).
 
             On a __weak hit__, as above, but you must also choose one:
-              * It’s worse than you thought: [Endure Harm](datasworn:move:starforged/suffer/endure_harm).
-              * You are overcome: [Endure Stress](datasworn:move:starforged/suffer/endure_stress).
+              * It’s worse than you thought: [Endure Harm](datasworn:move:elegy/suffer/endure_harm).
+              * You are overcome: [Endure Stress](datasworn:move:elegy/suffer/endure_stress).
               * Your victory is short-lived: A new danger or foe appears, or an existing danger worsens.
               * You suffer collateral damage: Something of value is lost or broken, or someone important must pay the cost.
               * You’ll pay for it: An objective falls out of reach.
               * Others won’t forget: You are marked for vengeance.
 
-            On a __miss__, you have lost this fight. [Pay the Price](datasworn:move:starforged/fate/pay_the_price).
+            On a __miss__, you have lost this fight. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
           outcomes:
             strong_hit:
-              text: On a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent.
+              text: On a __strong hit__, this foe is no longer in the fight. They are killed, out of action, flee, or surrender as appropriate to the situation and your intent ([Ask the Oracle](datasworn:move:elegy/adventure/ask_the_oracle) if unsure).
             weak_hit:
               text: |-
                 On a __weak hit__, as above, but you must also choose one:
@@ -1267,7 +1281,7 @@ moves:
                     * You’ll pay for it: An objective falls out of reach.
                     * Others won’t forget: You are marked for vengeance.
             miss:
-              text: On a __miss__, you have lost this fight. [Pay the Price](datasworn:move:starforged/fate/pay_the_price).
+              text: On a __miss__, you have lost this fight. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
           _source:
             <<: *Source
             page: 8
@@ -1277,29 +1291,24 @@ moves:
         type: move
         roll_type: action_roll
         trigger:
-          text: When you fight a battle, and it happens in a blur, and you...
+          text: When you fight a battle, and it happens in a blur...
           conditions:
-            - text: Fight at range, or using your speed and the terrain to your advantage
+            - text: Fight at range or using your speed or trickery to your advantage
               method: player_choice
               roll_options:
                 - using: stat
                   stat: dexterity
-            - text: Fight depending on your courage, allies, or companions
+            - text: Fight depending on your courage, leadership, or companions
               method: player_choice
               roll_options:
                 - using: stat
                   stat: heart
-            - text: Fight in close to overpower your opponents
+            - text: Fight in close to overpower your foe
               method: player_choice
               roll_options:
                 - using: stat
                   stat: force
-            - text: Fight using trickery to befuddle your opponents
-              method: player_choice
-              roll_options:
-                - using: stat
-                  stat: dexterity
-            - text: Fight using careful tactics to outsmart your opponents
+            - text: Fight using careful tactics to outsmart your foe
               method: player_choice
               roll_options:
                 - using: stat
@@ -1310,21 +1319,20 @@ moves:
         text: |-
           When __you fight a battle, and it happens in a blur__, envision your objective and roll. If you primarily...
 
-            * Fight at range, or using your speed and the terrain to your advantage: Roll +dexterity.
-            * Fight depending on your courage, allies, or companions: Roll +heart.
-            * Fight in close to overpower your opponents: Roll +force.
-            * Fight using trickery to befuddle your opponents: Roll +dexterity.
-            * Fight using careful tactics to outsmart your opponents: Roll +intellect.
+            * Fight at range or using your speed or trickery to your advantage: Roll +dexterity.
+            * Fight depending on your courage, leadership, or companions: Roll +heart.
+            * Fight in close to overpower your foe: Roll +force.
+            * Fight using careful tactics to outsmart your foe: Roll +intellect.
 
-          On a __strong hit__, you achieve your objective unconditionally. Take +2 momentum.
+          On a __strong hit__, you achieve your objective unconditionally. You and any allies who joined the battle may take +2 focus.
 
           On a __weak hit__, you achieve your objective, but not without cost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
 
-          On a __miss__, you are defeated and the objective is lost to you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+          On a __miss__, you are defeated or the objective is lost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
         outcomes:
           strong_hit:
-            text: On a __strong hit__, you achieve your objective unconditionally. Take +2 momentum.
+            text: On a __strong hit__, you achieve your objective unconditionally. You and any allies who joined the battle may take +2 focus.
           weak_hit:
             text: On a __weak hit__, you achieve your objective, but not without cost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
           miss:
-            text: On a __miss__, you are defeated and the objective is lost to you. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).
+            text: On a __miss__, you are defeated or the objective is lost. [Pay the Price](datasworn:move:elegy/suffer/pay_the_price).

--- a/source_data/elegy/moves.yaml
+++ b/source_data/elegy/moves.yaml
@@ -848,7 +848,7 @@ moves:
           
           - On a __weak hit__, you press on.
           
-          - On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the following table:
+          - On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the following table:
 
           {{table>move.oracle_rollable:elegy/suffer/endure_stress.endure_stress}}
 
@@ -862,7 +862,7 @@ moves:
             text: On a __weak hit__, you press on.
           miss:
             text: |-
-              On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or traumatized (if currently unmarked) or roll on the list below.
+              On a __miss__, also suffer -1 focus. If you are at 0 spirit, you must mark shaken or corrupted (if currently unmarked) or roll on the list below.
         oracles:
           endure_stress:
             name: Endure Stress Consequences

--- a/source_data/elegy/oracles/action_and_theme.yaml
+++ b/source_data/elegy/oracles/action_and_theme.yaml
@@ -22,8 +22,8 @@ oracles:
         dice: 1d100
         canonical_name: 'Action'
         suggestions:
-            - oracle_rollable:classic/action_and_theme/theme
-        summary: Use this table to inspire a discovery, event, character goal, or situation. A roll on this table can be combined with a [Theme](datasworn:oracle_rollable:classic/action_and_theme/theme) to provide an action and a subject. Then, interpret the result based on the context of the question and your current situation.
+            - oracle_rollable:elegy/action_and_theme/themes
+        summary: Use this table to inspire a discovery, event, character goal, or situation. A roll on this table can be combined with a [Theme](datasworn:oracle_rollable:elegy/action_and_theme/themes) to provide an action and a subject. Then, interpret the result based on the context of the question and your current situation.
         _source:
           <<: *Source
           page: 134

--- a/source_data/elegy/oracles/ambiance.yaml
+++ b/source_data/elegy/oracles/ambiance.yaml
@@ -24,6 +24,7 @@ oracles:
           dice: 1d100
           _source:
             <<: *Source
+            page: 139
           rows:
             - roll: { min: 1, max: 2 }
               text: Distant sirens wail through the night
@@ -135,6 +136,7 @@ oracles:
         dice: 1d100
         _source:
           <<: *Source
+          page: 140
         rows:    
           - roll: { min: 1, max: 2 }
             text: Flickering fluorescent lights hum softly
@@ -236,6 +238,5 @@ oracles:
             text: Ticking clocks mark the passage of time
           - roll: { min: 99, max: 100 }
             text: An old radio plays haunting melodies from another era
-
 
 

--- a/source_data/elegy/oracles/character.yaml
+++ b/source_data/elegy/oracles/character.yaml
@@ -24,6 +24,7 @@ oracles:
         dice: 1d100
         _source:
           <<: *Source
+          page: 135
         rows:
           - roll: { min: 1, max: 2 }
             text: Addicted
@@ -135,6 +136,7 @@ oracles:
         dice: 1d100
         _source:
           <<: *Source
+          page: 135
         rows:
           - roll: { min: 1, max: 2 }
             text: Police
@@ -245,6 +247,7 @@ oracles:
         dice: 1d30
         _source:
           <<: *Source
+          page: 135
         rows:
           - roll: { min: 1, max: 1 }
             text: Obtain an object
@@ -316,6 +319,7 @@ oracles:
         dice: 1d10
         _source:
           <<: *Source
+          page: 135
         rows:
           - roll: { min: 1, max: 1 }
             text: Indifferent

--- a/source_data/elegy/oracles/locations.yaml
+++ b/source_data/elegy/oracles/locations.yaml
@@ -24,6 +24,7 @@ oracles:
         dice: 1d100
         _source:
           <<: *Source
+          page: 141
         rows:
           - roll: { min: 1, max: 1 }
             text: City Hall
@@ -88,140 +89,142 @@ oracles:
           - roll: { min: 31, max: 31 }
             text: Bookstore
           - roll: { min: 32, max: 32 }
-            text: Music Venue
+            text: Yoga Studio
           - roll: { min: 33, max: 33 }
-            text: Grocery Store
+            text: Music Venue
           - roll: { min: 34, max: 34 }
-            text: Park Bench
+            text: Grocery Store
           - roll: { min: 35, max: 35 }
-            text: Public Pool
+            text: Park Bench
           - roll: { min: 36, max: 36 }
-            text: Laundromat
+            text: Public Pool
           - roll: { min: 37, max: 37 }
-            text: Pharmacy
+            text: Laundromat
           - roll: { min: 38, max: 38 }
-            text: Hardware Store
+            text: Pharmacy
           - roll: { min: 39, max: 39 }
-            text: Bike Shop
-          - roll: { min: 40, max: 40 }
-            text: Food Truck Park
-          - roll: { min: 41, max: 41 }
-            text: Public Restroom
-          - roll: { min: 42, max: 42 }
-            text: Office Building
-          - roll: { min: 43, max: 43 }
-            text: Beauty Salon
-          - roll: { min: 44, max: 44 }
-            text: Gas Station
-          - roll: { min: 45, max: 45 }
-            text: Food Court
-          - roll: { min: 46, max: 46 }
-            text: Library
-          - roll: { min: 47, max: 47 }
-            text: Skate Park
-          - roll: { min: 48, max: 48 }
-            text: Tennis Court
-          - roll: { min: 49, max: 49 }
-            text: Playground
-          - roll: { min: 50, max: 50 }
-            text: Mini Golf Course
-          - roll: { min: 51, max: 51 }
-            text: Car Dealership
-          - roll: { min: 52, max: 52 }
-            text: Bowling Alley
-          - roll: { min: 53, max: 53 }
-            text: Dog Park
-          - roll: { min: 54, max: 54 }
-            text: Golf Course
-          - roll: { min: 55, max: 55 }
-            text: Police Academy
-          - roll: { min: 56, max: 56 }
-            text: Bus Stop
-          - roll: { min: 57, max: 57 }
-            text: Comedy Club
-          - roll: { min: 58, max: 58 }
-            text: Flower Shop
-          - roll: { min: 59, max: 59 }
-            text: Antique Store
-          - roll: { min: 60, max: 60 }
-            text: Yoga Studio
-          - roll: { min: 61, max: 61 }
-            text: Movie Rental Store
-          - roll: { min: 62, max: 62 }
-            text: Music Store
-          - roll: { min: 63, max: 63 }
-            text: Garden
-          - roll: { min: 64, max: 64 }
-            text: Pawn Shop
-          - roll: { min: 65, max: 65 }
-            text: Escape Room
-          - roll: { min: 66, max: 66 }
-            text: Art Supply Store
-          - roll: { min: 67, max: 67 }
-            text: Thrift Store
-          - roll: { min: 68, max: 68 }
-            text: Dance Studio
-          - roll: { min: 69, max: 69 }
-            text: Recording Studio
-          - roll: { min: 70, max: 70 }
-            text: Boxing Gym
-          - roll: { min: 71, max: 71 }
             text: Hardware Store
-          - roll: { min: 72, max: 72 }
-            text: Brewery
-          - roll: { min: 73, max: 73 }
-            text: Music School
-          - roll: { min: 74, max: 74 }
-            text: Theater Company
-          - roll: { min: 75, max: 75 }
-            text: Retirement Home
-          - roll: { min: 76, max: 76 }
-            text: Auto Repair Shop
-          - roll: { min: 77, max: 77 }
-            text: Paintball Arena
-          - roll: { min: 78, max: 78 }
-            text: Farmers Market
-          - roll: { min: 79, max: 79 }
-            text: Trampoline Park
-          - roll: { min: 80, max: 80 }
-            text: Karaoke Bar
-          - roll: { min: 81, max: 81 }
-            text: Board Game Cafe
-          - roll: { min: 82, max: 82 }
-            text: Comic Book Store
-          - roll: { min: 83, max: 83 }
-            text: Furniture Store
-          - roll: { min: 84, max: 84 }
-            text: Tailor Shop
-          - roll: { min: 85, max: 85 }
+          - roll: { min: 40, max: 40 }
+            text: Bike Shop
+          - roll: { min: 41, max: 41 }
+            text: Food Truck Park
+          - roll: { min: 42, max: 42 }
+            text: Public Restroom
+          - roll: { min: 43, max: 43 }
+            text: Office Building
+          - roll: { min: 44, max: 44 }
+            text: Beauty Salon
+          - roll: { min: 45, max: 45 }
+            text: Gas Station
+          - roll: { min: 46, max: 46 }
+            text: Food Court
+          - roll: { min: 47, max: 47 }
+            text: Library
+          - roll: { min: 48, max: 48 }
+            text: Skate Park
+          - roll: { min: 49, max: 49 }
+            text: Tennis Court
+          - roll: { min: 50, max: 50 }
+            text: Playground
+          - roll: { min: 51, max: 51 }
+            text: Mini Golf Course
+          - roll: { min: 52, max: 52 }
+            text: Car Dealership
+          - roll: { min: 53, max: 53 }
+            text: Bowling Alley
+          - roll: { min: 54, max: 54 }
+            text: Dog Park
+          - roll: { min: 55, max: 55 }
+            text: Golf Course
+          - roll: { min: 56, max: 56 }
+            text: Police Academy
+          - roll: { min: 57, max: 57 }
+            text: Bus Stop
+          - roll: { min: 58, max: 58 }
+            text: Comedy Club
+          - roll: { min: 59, max: 59 }
+            text: Flower Shop
+          - roll: { min: 60, max: 60 }
+            text: Antique Store
+          - roll: { min: 61, max: 61 }
             text: Yoga Studio
+          - roll: { min: 62, max: 62 }
+            text: Movie Rental Store
+          - roll: { min: 63, max: 63 }
+            text: Music Store
+          - roll: { min: 64, max: 64 }
+            text: Garden
+          - roll: { min: 65, max: 65 }
+            text: Pawn Shop
+          - roll: { min: 66, max: 66 }
+            text: Escape Room
+          - roll: { min: 67, max: 67 }
+            text: Art Supply Store
+          - roll: { min: 68, max: 68 }
+            text: Thrift Store
+          - roll: { min: 69, max: 69 }
+            text: Dance Studio
+          - roll: { min: 70, max: 70 }
+            text: Recording Studio
+          - roll: { min: 71, max: 71 }
+            text: Boxing Gym
+          - roll: { min: 72, max: 72 }
+            text: Hardware Store
+          - roll: { min: 73, max: 73 }
+            text: Brewery
+          - roll: { min: 74, max: 74 }
+            text: Music School
+          - roll: { min: 75, max: 75 }
+            text: Theater Company
+          - roll: { min: 76, max: 76 }
+            text: Retirement Home
+          - roll: { min: 77, max: 77 }
+            text: Auto Repair Shop
+          - roll: { min: 78, max: 78 }
+            text: Paintball Arena
+          - roll: { min: 79, max: 79 }
+            text: Farmers Market
+          - roll: { min: 80, max: 80 }
+            text: Trampoline Park
+          - roll: { min: 81, max: 81 }
+            text: Karaoke Bar
+          - roll: { min: 82, max: 82 }
+            text: Board Game Cafe
+          - roll: { min: 83, max: 83 }
+            text: Comic Book Store
+          - roll: { min: 84, max: 84 }
+            text: Furniture Store
+          - roll: { min: 85, max: 85 }
+            text: Tailor Shop
           - roll: { min: 86, max: 86 }
-            text: Dance Club
+            text: Yoga Studio
           - roll: { min: 87, max: 87 }
-            text: Gym
+            text: Dance Club
           - roll: { min: 88, max: 88 }
-            text: Skate Shop
+            text: Gym
           - roll: { min: 89, max: 89 }
-            text: Shooting Range
+            text: Skate Shop
           - roll: { min: 90, max: 90 }
-            text: Home Decor Store
+            text: Shooting Range
           - roll: { min: 91, max: 91 }
-            text: Juice Bar
+            text: Home Decor Store
           - roll: { min: 92, max: 92 }
-            text: Pottery Studio
+            text: Juice Bar
           - roll: { min: 93, max: 93 }
-            text: Tea House
+            text: Pottery Studio
           - roll: { min: 94, max: 94 }
-            text: Boxing Studio
+            text: Tea House
           - roll: { min: 95, max: 95 }
-            text: Arts Center
+            text: Boxing Studio
           - roll: { min: 96, max: 96 }
-            text: Go-Kart Track
+            text: Arts Center
           - roll: { min: 97, max: 97 }
-            text: Laser Tag Arena
+            text: Go-Kart Track
           - roll: { min: 98, max: 98 }
-            text: Retro Arcade
+            text: Laser Tag Arena
           - roll: { min: 99, max: 99 }
+            text: Retro Arcade
+          - roll: { min: 100, max: 100 }
             text: Outdoor Concert Venue
 
       district:
@@ -233,6 +236,7 @@ oracles:
         dice: 1d6
         _source:
           <<: *Source
+          page: 142
         rows:
           - roll: { min: 1, max: 1 }
             text: Downtown
@@ -256,6 +260,7 @@ oracles:
         dice: 1d10
         _source:
           <<: *Source
+          page: 142
         rows:
           - roll: { min: 1, max: 1 }
             text: Blue Grove Hotel
@@ -287,6 +292,7 @@ oracles:
         dice: 1d10
         _source:
           <<: *Source
+          page: 142
         rows:
           - roll: { min: 1, max: 1 }
             text: Bubble Plex Cinema
@@ -318,6 +324,7 @@ oracles:
         dice: 1d10
         _source:
           <<: *Source
+          page: 142
         rows:
           - roll: { min: 1, max: 1 }
             text: Georgia Beach
@@ -349,6 +356,7 @@ oracles:
         dice: 1d10
         _source:
           <<: *Source
+          page: 142
         rows:
           - roll: { min: 1, max: 1 }
             text: Cielo Library
@@ -380,6 +388,7 @@ oracles:
         dice: 1d10
         _source:
           <<: *Source
+          page: 142
         rows:
           - roll: { min: 1, max: 1 }
             text: Castilla Mall
@@ -411,6 +420,7 @@ oracles:
         dice: 1d10
         _source:
           <<: *Source
+          page: 142
         rows:
           - roll: { min: 1, max: 1 }
             text: Brass Star convenience

--- a/source_data/elegy/oracles/name.yaml
+++ b/source_data/elegy/oracles/name.yaml
@@ -236,7 +236,7 @@ oracles:
         dice: 1d100
         _source:
           <<: *Source
-          page: 134
+          page: 133
         rows:
           - roll: { min: 1, max: 1 }
             text: Aaron

--- a/source_data/elegy/oracles/story.yaml
+++ b/source_data/elegy/oracles/story.yaml
@@ -24,6 +24,7 @@ oracles:
           dice: 1d100
           _source:
             <<: *Source
+            page: 136
           rows:
             - roll: { min: 1, max: 2 }
               text: Affirms a previously understood fact or clue
@@ -135,6 +136,7 @@ oracles:
           dice: 1d100
           _source:
             <<: *Source
+            page: 137
           rows:
             - roll: { min: 1, max: 3 }
               text: Supernatural power fails
@@ -211,6 +213,7 @@ oracles:
           dice: 1d100
           _source:
             <<: *Source
+            page: 137
           rows:
             - roll: { min: 1, max: 2 }
               text: Influential vampire disappears mysteriously

--- a/source_data/elegy/rules.yaml
+++ b/source_data/elegy/rules.yaml
@@ -2,7 +2,7 @@ _id: elegy
 datasworn_version: "0.1.0"
 type: ruleset
 <<:  &Source
-  title: 'Elegy 3.5 truths'
+  title: 'Elegy 3.5'
   license: https://creativecommons.org/licenses/by-nc-sa/4.0
   url: https://miraclem.itch.io/elegy
   date: 2024-07-31
@@ -24,7 +24,6 @@ rules:
       label: blood
       max: 5
       value: 5
-      shared: true
       description: Blood represents how much your hunger for blood is sated.
   impacts:
     misfortunes:
@@ -33,41 +32,50 @@ rules:
       contents:
         wounded:
           label: wounded
-          description: Wounded may be marked when you are at 0 health and fail to [Endure Harm](datasworn:move:starforged/suffer/endure_harm). You are severely injured.
+          description: Wounded may be marked when you are at 0 health and suffer harm ([Endure Harm](datasworn:move:elegy/suffer/endure_harm)). You are severely injured.
           prevents_recovery:
             - health
         shaken:
           label: shaken
-          description: Shaken may be marked when you are at 0 spirit and fail to [Endure Stress](datasworn:move:starforged/suffer/endure_stress). You are despairing or distraught.
+          description: Shaken is marked when you are at 0 spirit and suffer stress ([Endure Stress](datasworn:move:elegy/suffer/endure_stress)). You are despairing or distraught.
           prevents_recovery:
             - spirit
         starving:
           label: starving
           description: Starving is marked when you are at 0 blood and lose blood. You are in a violent, hungry state. You lose 1 point of glamour and 1 of intellect.
-          shared: true
+          prevents_recovery:
+            - spirit
+            - blood
     lasting_effects:
       label: lasting effects
-      description: Lasting effects are permanent. They forever impact your character through the momentum adjustment and—more importantly—the narrative impact of being permanently harmed or traumatized. You should factor this impact into how you perform moves and how you interact with the world.
+      description: Lasting effects are permanent. They forever impact your character through the focus adjustment and—more importantly—the narrative impact of being permanently harmed or traumatized. You should factor this impact into how you perform moves and how you interact with the world.
       contents:
         permanently_harmed:
           label: permanently harmed
-          description: Permanently harmed may be marked when you are at 0 health and fail to [Endure Harm](datasworn:move:starforged/suffer/endure_harm). You have suffered a wound that you must reckon with, such as the loss of an eye or hand. Or you bear physical scars that are a constant reminder of a harrowing incident.
+          description: Permanently harmed may be marked when you are Wounded, at 0 health, and suffer harm ([Endure Harm](datasworn:move:elegy/suffer/endure_harm)). You have suffered a wound that you must reckon with, such as the loss of an eye or hand, or bear physical scars that are a constant reminder of a harrowing incident. When this impact is marked, you have 0 health and if you suffer more harm, you die your last death.
           permanent: true
         traumatized:
           label: traumatized
-          description: Traumatized may be marked when you are at 0 spirit and fail to [Endure Stress](datasworn:move:starforged/suffer/endure_stress). Your experiences have left you emotionally or mentally scarred.
+          description: Traumatized may be marked when you are Shaken, at 0 spirit, and suffer stress ([Endure Stress](datasworn:move:elegy/suffer/endure_stress)). Your experiences have left you emotionally or mentally scarred. When this impact is marked, you have 0 spirit and if you suffer more stress, your mind is forever lost.
           permanent: true
         sinner:
           label: sinner
-          description: Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood and you spend more blood, you lose complete touch with your human side and turn into a beast.
+          description: Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood. If you spend more blood, you lose complete touch with your human side and turn into a beast.
           permanent: true
+    burdens:
+      label: burdens
+      description: Burdens are a result of life-changing experiences that leave you bound to quests. Clearing a burden can only be accomplished by resolving the quest.
+      contents:
+        cursed:
+          label: cursed
+          description: Cursed is marked when you [Face Last Death](datasworn:move:elegy/suffer/face_last_death) and return to the mortal world with a soul-bound quest. This burden can only be cleared by completing the quest.
+        tormented:
+          label: tormented
+          description: Tormented is marked when you [Face Desolation](datasworn:move:elegy/suffer/face_desolation), gain visions of a dreaded event coming to pass, and undertake a quest to prevent it. This burden can only be cleared by completing the quest.
   special_tracks:
     elegies:
       label: elegies
       description: Sing elegies and do what you must to see them fulfilled.
-      tags:
-        starforged:
-          legacy_track_xp: true
   stats:
     force:
       label: force

--- a/source_data/elegy/rules.yaml
+++ b/source_data/elegy/rules.yaml
@@ -56,11 +56,11 @@ rules:
           permanent: true
         traumatized:
           label: traumatized
-          description: Traumatized may be marked when you are Shaken, at 0 spirit, and suffer stress ([Endure Stress](datasworn:move:elegy/suffer/endure_stress)). Your experiences have left you emotionally or mentally scarred. When this impact is marked, you have 0 spirit and if you suffer more stress, your mind is forever lost.
+          description: Traumatized may be marked when you are Shaken, at 0 spirit and suffers stress. Your experiences have left you emotionally or mentally scarred. When this impact is marked, you have 0 health and you suffer more stress, your mind is forever lost.
           permanent: true
         sinner:
           label: sinner
-          description: Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood. If you spend more blood, you lose complete touch with your human side and turn into a beast.
+          description: Sinner may be marked when you are Starving, at 0 blood and spend blood. You get so frenzied, you commit something that angers your ruler. Envision what it is and what she asks of you in exchange for letting you live. When this impact is marked, you have 0 blood and you spend more blood, you lose complete touch with your human side and turn into a beast.
           permanent: true
     burdens:
       label: burdens

--- a/source_data/elegy/truths.yaml
+++ b/source_data/elegy/truths.yaml
@@ -41,21 +41,21 @@ truths:
       page: 3
     options:
       - roll: { min: 1, max: 33 }
-        summary: Vampirism is a genetic mutation.
+        summary: …a genetic mutation, and vampires are their own species.
         description: |-
-          Vampires are their own species, integral to the balance of the world’s ecosystem, albeit in a supernatural way.
+          Ages ago, vampires already believed they were integral to the balance of the world’s ecosystem, if not in a natural way, in a supernatural one.
         quest_starter: |-
           A renowned biologist is conducting an experiment on vampire blood, threatening the Façade. How do you get involved in this situation? How do you plan to silence her?
       - roll: { min: 34, max: 67 }
-        summary: Vampirism is a punishment for humanity’s original sins.
+        summary: …a punishment for humanity’s original sins.
         description: |-
-          The curse unfolded when the first murder occurred, and a higher power condemned the killer and her descendants to an eternal nocturnal existence.
+          The curse unfolded when the first murder occurred, and a higher power condemned the killer and her descendants, ensuring they would never again walk under the sun. This marked the origin of the first vampire.
         quest_starter: |-
           A cryptic parchment telling the story of the first murder has been found. It’s in a strange language, and it seems to reveal new details of the story. How will you translate it? What details are these?
       - roll: { min: 68, max: 100 }
-        summary: Vampirism is an eternal enigma.
+        summary: …an eternal enigma.
         description: |-
-          Even the most enlightened vampires harbor conflicting opinions on this matter, and there is no definitive answer.
+          Even the most enlightened vampires harbor conflicting opinions on this matter. Each individual’s perspective significantly shapes their interpretation, and there is no definitive answer to this question.
         quest_starter: |-
           Vampires form a cult around the idea that it’s possible to turn back into mere humans, but mortal authorities suspect something is not right with them. Why do you step in this situation?
   superstitions:
@@ -66,23 +66,23 @@ truths:
       page: 4
     options:
       - roll: { min: 1, max: 33 }
-        summary: Most superstitions about vampires are untrue.
+        summary: Most of what you heard about vampires is untrue.
         description: |-
           They are not deterred by crucifixes, garlic, or holy water, and they can enter private domains without invitation. A stake through the heart merely paralyzes them.
         quest_starter: |-
-          A suspicious mortal is guarding a place with garlic and crosses. While she is clearly superstitious, she seems to be holding something of importance within said place. What gives it away? How do you get involved in discovering what it is?
+          A suspicious mortal is guarding a place with garlic and crosses. While she is clearly superstitious, she seems to be holding something of importance within said place. What gives it away? How do you get yourself involved in discovering what it is? What is this place?
       - roll: { min: 34, max: 67 }
-        summary: Superstitions about vampires reflect the truth.
+        summary: They reflect the real deal.
         description: |-
-          Garlic, holy water, crucifixes, and other religious symbols are actually harmful. A stake to the heart will kill them, and they cannot enter uninvited.
+          They’re not superstitions. Garlic, holy water, crucifixes, and other religious symbols are actually harmful to vampires. A stake to the heart will kill them, and they can’t enter a home or private domain if they’re not invited to. This alternative enables the Superstition optional damage rule in page 40.
         quest_starter: |-
           Garlic gas was released in the ventilation system of your progenitor. Who is the culprit? Why does she want to harm your progenitor?
       - roll: { min: 68, max: 100 }
-        summary: Religious symbols are dangerous in the hands of faithful people.
+        summary: Religious symbols are dangerous in the hands of actually faithful people.
         description: |-
-          Authentic Faith is a supernatural force rooted in sincere belief. Mortals with Authentic Faith can wield divine symbols to harm vampires.
+          Authentic Faith is a supernatural force rooted in sincere, unwavering belief in a higher power, be it a religious deity or a philosophical concept. Mortals with Authentic Faith who wield divine symbols are capable of warding off and even hurting supernatural creatures, particularly vampires. A stake to the heart will paralyze a vampire. This alternative enables the Authentic Faith optional damage rule in page 41.
         quest_starter: |-
-          A visiting bishop in Santa Maria plans to bless the water in a large fountain, transforming it into a potent weapon against your kind. How will you stop her? What symbol does she carry?
+          A visiting bishop in Santa Maria plans to bless the water in a large fountain, transforming it into a potent weapon against your kind. How will you stop her, considering she always carries with herself a sacred symbol that can harm you? What symbol is this?
   genealogy:
     name: Genealogy
     type: truth
@@ -91,23 +91,23 @@ truths:
       page: 5
     options:
       - roll: { min: 1, max: 33 }
-        summary: Vampires share a single progenitor.
+        summary: Depending on their progenitor, each vampire belongs to one of five different lineages.
         description: |-
-          All vampires trace their lineage back to a single source, creating a complex web of relationships and responsibilities.
+          Every vampire is affiliated with one of several “families,” each characterized by distinct traditions and manifestations of vampirism. Lineages are transmitted when one vampire creates another, with each lineage embodying a specific archetype of the vampire myth, bestowing unique powers and inclinations. Members of a lineage may not necessarily resemble or behave like each other. This alternative enables the Lineages optional rule in page 76.
         quest_starter: |-
-          A lost lineage chart has resurfaced, revealing the connections between several powerful vampires. Who has it, and why is it causing turmoil?
+          A vampire serial killer is targeting victims of a specific lineage. Which one is it, and why? What compels you to step forward and go after her?
       - roll: { min: 34, max: 67 }
-        summary: Vampires are divided into distinct clans or families.
+        summary: All vampires are unique and different from one another.
         description: |-
-          Each clan has its own unique characteristics, powers, and traditions, often leading to rivalries.
+          Vampirism manifests in what seems like a random manner, and each vampire is a unique entity with its own set of features.
         quest_starter: |-
-          A clan leader has gone missing, throwing their followers into disarray. What role do you play in this power vacuum?
+          A newborn vampire went missing. You know she had a unique ability, which should help you track her. What ability is this? Why do you swear to find the newborn?
       - roll: { min: 68, max: 100 }
-        summary: Vampires are solitary by nature.
+        summary: Vampires inherit one power from their progenitor.
         description: |-
-          Most vampires avoid forming large communities, preferring independence and secrecy, but some exceptions exist.
+          While powers may develop in a more diverse fashion over time, all new vampires begin their undead existence inheriting one special ability from their progenitor. This ability is random.
         quest_starter: |-
-          An enigmatic vampire is attempting to unite solitary vampires under a single banner. Why does this concern you?
+          Two newborn vampires don’t know where they come from, but believe they share the same progenitor. What power do they share? Why do you agree to help? Who is the progenitor?
   what_mortals_know:
     name: What Mortals Know
     type: truth
@@ -116,23 +116,23 @@ truths:
       page: 6
     options:
       - roll: { min: 1, max: 33 }
-        summary: Mortals remain blissfully ignorant of vampires.
+        summary: While it’s not exactly legal, it’s not uncommon for vampires to have human allies of some sort.
         description: |-
-          Few mortals are aware of the existence of vampires, as the Façade remains strong and well-guarded.
+          Having connections with individuals possessing valuable skills or occupying influential positions is advantageous, whether one is undead or not. However, it’s crucial to exercise caution. Before disclosing your true nature, ensure that these individuals have a significant stake in maintaining your secret, that revealing the truth about you won’t be easily believed by others, and that they don’t intend to harm you.
         quest_starter: |-
-          A mortal investigator has come dangerously close to uncovering the truth. How do you handle them?
+          A friendly mortal contact begs you to find her child, who has been kidnapped. How will you track down the culprits? Where is she? Do you ask something in return?
       - roll: { min: 34, max: 67 }
-        summary: Some mortals suspect the truth.
+        summary: Secret organizations know vampires exist, and hunters are a threat.
         description: |-
-          Myths, rumors, and conspiracies about vampires persist, and some mortals actively seek to prove their existence.
+          While vampires may go unnoticed by the majority, certain secret societies possessing occult knowledge remain vigilant. Among them are black ops agencies dedicated to unveiling the vampiric nature, alongside centuries-old religious circles committed to eradicating every monstrous entity. Investigators, spies, vampire hunters, and paramilitary units pose a tangible threat to the vampire community. This alternative gives access to the Mortal Threats NPCs.
         quest_starter: |-
-          A secret society dedicated to hunting vampires is operating in Santa Maria. How do you deal with them?
+          Vampires are being killed in a serial fashion that seems to be the work of a skilled vampire killer. What’s her modus operandi? How do you intend to catch her? What’s in it for you?
       - roll: { min: 68, max: 100 }
-        summary: Mortals are aware of vampires.
+        summary: Basically no one knows vampires exist.
         description: |-
-          Vampires are an open secret, and society has adapted to coexist with them—albeit uneasily.
+          Besides mannequins — the human blood bags some vampires have — the Façade requires absolute secrecy and is enforced in a very efficient way. Those who know too much are immediately silenced.
         quest_starter: |-
-          A mortal lawmaker proposes harsh restrictions on vampire activities. How do you influence this process?
+          Someone took pictures of you while you were feeding. This could mean a devastating blow to the Façade and a sentence for you. How can you prevent them from causing this damage? Where can you find the photographer? Who is behind all this?
 
   the_internet:
     name: The Internet
@@ -142,23 +142,23 @@ truths:
       page: 7
     options:
       - roll: { min: 1, max: 33 }
-        summary: The internet is a useful tool for vampires.
+        summary: Using the internet is prohibited by law.
         description: |-
-          Vampires use the internet to communicate, gather information, and maintain the Façade with relative ease.
+          In today’s world, no information is truly secure. A single slip, and the Façade will crumble.
         quest_starter: |-
-          A hacker has discovered a vampire-only online forum and threatens to expose it. What steps do you take?
+          A ghost hunting YouTube show crew just got actual vampire activity on camera. What did they capture? How will you protect the Façade from them?
       - roll: { min: 34, max: 67 }
-        summary: The internet poses significant risks.
+        summary: Using the internet is permitted.
         description: |-
-          The transparency of the digital age has made it harder for vampires to remain hidden, leading to frequent breaches of the Façade.
+          As long as you keep your unnatural habits away from social media and use fake accounts, you may use the internet however you want.
         quest_starter: |-
-          A viral video appears to capture undeniable evidence of vampiric activity. How do you address the fallout?
+          A couple of young vampires share their unlives openly in social media. Why do you step in to stop them? What’s the last Façade-breaking thing they tweeted?
       - roll: { min: 68, max: 100 }
-        summary: Vampires avoid the internet.
+        summary: Vampires have their own network, the umbernet.
         description: |-
-          Fearing exposure and surveillance, most vampires steer clear of the digital world, relying on older methods of communication.
+          Even though regular internet use is prohibited, the umbernet links all major vampire cities in a secure web, resistant to mortal interference and private. While it doesn’t encompass all the information available on the internet, its functionality is similar.
         quest_starter: |-
-          A mortal journalist questions why you are absent from online records. How do you explain this?
+          Sensitive documents of one of your acquaintances were leaked from the umbernet to the internet. How do you intend to investigate this case? What does she promise you in return for your aid in finding the culprit?
   rebels:
     name: Rebels
     type: truth
@@ -167,23 +167,23 @@ truths:
       page: 8
     options:
       - roll: { min: 1, max: 33 }
-        summary: Rebels seek to overthrow vampire society.
+        summary: Plenty of vampires don’t agree totally with the queen, and sometimes they form groups.
         description: |-
-          Dissatisfied with the current order, these vampires aim to dismantle traditional hierarchies and establish a new regime.
+          These groups can be united by any social or political idea. The bigger ones can even have some influence, but they are never powerful enough to actually challenge the queen.
         quest_starter: |-
-          A rebel leader offers you a place in their ranks. Why do you consider—or reject—their offer?
+          A small group of vampires is accusing and exposing a corrupt, bloodthirsty captain they want to take down. Why is taking part in this situation important to you? Who do you support?
       - roll: { min: 34, max: 67 }
-        summary: Rebels challenge specific norms.
+        summary: Those who don’t agree with the queen’s rule will be silenced or punished.
         description: |-
-          Not all rebels seek revolution; some fight for changes within the system, targeting outdated customs or oppressive practices.
+          The queen’s law is absolute. Any organized political divergence from the traditions that hold her in power is a threat that must be eliminated.
         quest_starter: |-
-          A group of young vampires begins to protest a centuries-old law. How do you become involved in their movement?
+          Your progenitor was accused of conspiring against the queen. Written evidence that connects her to a radical group was found, but she swears the letters are forged. Who is the culprit?
       - roll: { min: 68, max: 100 }
-        summary: Rebels are outcasts.
+        summary: The Agorean Movement is an independent Faction that questions the queen’s authority and governs part of Santa Maria.
         description: |-
-          Rebels are a fringe element, shunned and hunted by mainstream vampire society for their defiance.
+          They advocate for individual freedom and self-governance, and resist the constraints of the queen’s law. While their ranks include diverse ideologies, from idealists to nihilists, the common thread among them is a desire to challenge authority, question ancient traditions, and create a more egalitarian and liberated existence for vampires. This alternative gives access to the Agorean Movement NPCs.
         quest_starter: |-
-          A rebel in hiding seeks your protection. Why do you help—or betray—them?
+          An Agorean militant believes her collective’s leader is a spy from the Olympus. Why does she trust you to uncover her leader’s true colors? What does this collective fight for?
   blood_sorcery:
     name: Blood Sorcery
     type: truth
@@ -192,23 +192,23 @@ truths:
       page: 9
     options:
       - roll: { min: 1, max: 33 }
-        summary: Blood sorcery is a rare and forbidden art.
+        summary: The powers of blood don’t manifest themselves through silly rituals
         description: |-
-          Only a few vampires dare to practice this dangerous magic, as it is heavily restricted by vampire law.
+          While some individuals may follow peculiar esoteric traditions, the concept of vampiric blood sorcery is nonexistent in our world. Rituals are not a part of our reality.
         quest_starter: |-
-          A powerful sorcerer demands a rare ingredient for a ritual. Why do you choose to aid—or oppose—them?
+          A vampire is conducting mystical ceremonies involving animal sacrifice. The disappearance of numerous animals is making mortal society suspicious. How do you make her stop? What is her favorite animal to sacrifice, and why?
       - roll: { min: 34, max: 67 }
-        summary: Blood sorcery is widely practiced.
+        summary: Vampires who know blood sorcery rituals are rare, but often powerful and wise.
         description: |-
-          Many vampires use blood sorcery to enhance their powers, though it often comes with significant risks and costs.
+          They keep out of sight, so their methods stay secret, but they sometimes take vampires as pupils when they are worthy.
         quest_starter: |-
-          A rival vampire challenges you to a duel of sorcery. What stakes do you set, and how do you prepare?
+          Rumors say there’s an elder in Santa Maria who could teach you rituals — if you manage to find and convince her. Why are you so eager to be her apprentice? Where will you start looking for her?
       - roll: { min: 68, max: 100 }
-        summary: Blood sorcery is mysterious and unpredictable.
+        summary: The Circle of Circe is a large, influential group of vampire mystics.
         description: |-
-          No one fully understands the origins or mechanics of blood sorcery, making it a source of both fascination and fear.
+          They are meticulous in their studies, developing complex rituals, and mastering the manipulation of supernatural forces. Their focus on the arcane arts gives them a reputation for being scholars and guardians of occult knowledge within the vampire society. This alternative gives access to the Circle of Circe NPCs.
         quest_starter: |-
-          An ancient text detailing lost sorceries has been uncovered. What lengths will you go to obtain it?
+          A bag of werewolf blood has been located in the local medical clinic. This not only endangers the Façade, as it would make a potent concoction for rituals, according to the vampire that contacts you. Why are you trusted with this quest? What do you get in return?
   religion:
     name: Religion
     type: truth
@@ -217,23 +217,23 @@ truths:
       page: 10
     options:
       - roll: { min: 1, max: 33 }
-        summary: Religion condemns vampires.
+        summary: The government has tones of faith.
         description: |-
-          Vampires are seen as cursed beings, and religious institutions often seek to destroy them.
+          The most important practices are held in a cult-like fashion, and the queen and other important figures act as priestesses in these situations. It’s something purely ceremonial, but it reflects the idea that the queen and her peers are more than simple vampires.
         quest_starter: |-
-          A priest begins to rally mortals against vampires in Santa Maria. How do you counter their influence?
+          An important ceremony that will happen soon requires half the blood of at least 3 mortals. Why does the queen trust you to collect it?
       - roll: { min: 34, max: 67 }
-        summary: Vampires hold religious beliefs.
+        summary: The Epitaph Order is a large and influential religious organization.
         description: |-
-          Many vampires adhere to faiths that accommodate their existence, blending mortal and vampiric spirituality.
+          On the one hand, faith and religion may be ignored by most vampires. On the other hand, they unite many vampires under a large group with its own particular interests. This alternative gives access to the Epitaph Order NPCs.
         quest_starter: |-
-          A sacred relic important to vampires is stolen. What role do you play in retrieving it?
+          A local mortal preacher has been saying things that go against the Epitaph Order’s ideals. What commandment do they inspire humans to break? Why do you agree to silence her?
       - roll: { min: 68, max: 100 }
-        summary: Religion is intertwined with vampirism.
+        summary: Almost no undead believes in a bigger power.
         description: |-
-          Some religious groups secretly include vampires, seeing them as chosen or cursed in alignment with their doctrines.
+          A few make prayers and have group meetings, but they have no political influence.
         quest_starter: |-
-          A religious sect offers you sanctuary and demands loyalty in return. How do you respond?
+          A vampire who was devoutly religious in life now attends nightly ceremonies associated with her former faith, drawing the curiosity of mortals who sense something’s wrong about her. What’s giving away that she’s not like them? How do you prevent her nature from being discovered by others?
   deviance:
     name: Deviance
     type: truth
@@ -242,23 +242,23 @@ truths:
       page: 11
     options:
       - roll: { min: 1, max: 33 }
-        summary: Deviance is rare among vampires.
+        summary: Vampires rarely break the three moral laws buried within their nature.
         description: |-
-          Most vampires adhere strictly to tradition and the Façade, avoiding behaviors that could endanger their kind.
+          Everybody has heard of a vampire drinking the blood of another, turning mortals into vampires without thinking twice, or even revealing their nature despite the risk, but they’re really abnormal cases.
         quest_starter: |-
-          A young vampire's reckless actions threaten the Façade. How do you intervene?
+          You hear rumors of a group of vampires killing others to use their vampiric blood to conduct dark, esoteric rites. What’s their story? What do they seek through these rites? Why do you swear to stop them?
       - roll: { min: 34, max: 67 }
-        summary: Deviance is a growing problem.
+        summary: A large group of vampires called the Egregoros rejects the three basic vampire laws and opposes anyone standing by them.
         description: |-
-          Some vampires challenge traditions and norms, creating conflict within vampire society.
+          They embrace a more anarchic and brutal existence, engaging in open warfare against their enemies and resorting to violence. This alternative gives access to the Egregoros NPCs.
         quest_starter: |-
-          A group of deviant vampires invites you to join them. What do they offer, and what risks does this pose?
+          Rumors say the Egregoros are planning to turn a serial killer into a vampire in one of their macabre rituals. How will you stop their plans?
       - roll: { min: 68, max: 100 }
-        summary: Deviance is widespread.
+        summary: Vampires who create blood links with others of their kind or even mortals are common.
         description: |-
-          Many vampires have abandoned traditional rules, forcing society to adapt or risk collapse.
+          They usually do it to establish a relationship of dominance and influence over the other individual.
         quest_starter: |-
-          A powerful vampire leader plans to reform society to accommodate deviance. What role do you play in their plans?
+          A nightclub owner is compelling her human employees to drink her blood, binding them as servants through blood linking. They exhibit extreme submissiveness towards her, but tensions arise as they begin to compete for their employer’s favor. Why do you intervene in this situation?
 
   werewolves:
     name: Werewolves
@@ -268,48 +268,23 @@ truths:
       page: 12
     options:
       - roll: { min: 1, max: 33 }
-        summary: Werewolves are mortal enemies of vampires.
+        summary: They live in packs within the city and call themselves lycanthropes.
         description: |-
-          Vampires and werewolves have an ancient feud, resulting in violent confrontations whenever they meet.
+          Werewolves are another type of creature that hides in the night. Vampires and werewolves are not necessarily enemies: sometimes, they cooperate to keep their existences in the shadows. This alternative gives access to the Lycanthrope NPCs.
         quest_starter: |-
-          A werewolf pack moves into Santa Maria, threatening your territory. How do you respond?
+          A pack of lycanthropes has taken an interest in a particular place, disrupting the local vampire hierarchy. Why do you involve yourself in this territorial dispute?
       - roll: { min: 34, max: 67 }
-        summary: Werewolves and vampires coexist uneasily.
+        summary: Are a subtype of mindless solitary monsters we call beast people.
         description: |-
-          While conflicts occur, both sides maintain an uneasy truce to avoid unnecessary bloodshed.
+          Beast people are mortals who turn into mindless monsters when the moon is full. Some turn into wolf-people, while others assume forms that resemble cats, rats, bears, etc. They’re never organized. This alternative gives access to the Beast People NPCs.
         quest_starter: |-
-          A werewolf requests your help against a common enemy. What do they offer in return?
+          A werecat is terrorizing an area of Santa Maria and bringing unwanted attention from mortals. How will you eliminate this threat?
       - roll: { min: 68, max: 100 }
-        summary: Werewolves are allies.
+        summary: Tribes of werewolves inhabit the wild. They call themselves varou.
         description: |-
-          Vampires and werewolves share common goals and often work together, though mistrust lingers.
+          They’re almost as numerous as vampires and are organized according to a complex tribal hierarchy. They seek to defend the natural balance of the universe against natural and unnatural threats. Because of that, vampires are their mortal enemies. This alternative gives access to the Varou NPCs.
         quest_starter: |-
-          A werewolf ally asks for your help in a dangerous ritual. What risks are involved, and why do you agree?
-  elegies:
-    name: Elegies
-    type: truth
-    _source:
-      <<: *Source
-      page: 13
-    options:
-      - roll: { min: 1, max: 33 }
-        summary: Elegies are forgotten.
-        description: |-
-          These haunting songs of loss and memory have faded from vampire society, known only to the oldest among them.
-        quest_starter: |-
-          An ancient vampire offers to teach you an elegy. What must you do to earn their trust?
-      - roll: { min: 34, max: 67 }
-        summary: Elegies are preserved.
-        description: |-
-          Vampires maintain a rich tradition of elegies, which serve as both art and history.
-        quest_starter: |-
-          A rival vampire challenges you to perform an elegy at a gathering. How do you prepare, and what story do you choose to tell?
-      - roll: { min: 68, max: 100 }
-        summary: Elegies are evolving.
-        description: |-
-          Modern vampires have adapted elegies to contemporary styles, blending old and new in innovative ways.
-        quest_starter: |-
-          A young vampire creates a controversial new elegy. How do you react, and what does it mean for vampire society?
+          A varou has been killing vampires that wander through a large park. Why do you promise to eliminate it or drive it away? What is your plan?
   mortal_magic:
     name: Mortal Magic
     type: truth
@@ -318,20 +293,45 @@ truths:
       page: 14
     options:
       - roll: { min: 1, max: 33 }
-        summary: Mortals rarely possess magic.
+        summary: The Crystal Compass is a global mage organization.
         description: |-
-          Magic is rare among mortals, and those who wield it are often unaware of their potential.
+          They follow their own individual path into magical enlightenment. This alternative gives access to the Crystal Compass NPCs.
         quest_starter: |-
-          A mortal accidentally casts a spell that reveals vampire activity. How do you address the situation?
+          Your progenitor suspects a mage from the Crystal Compass is plotting to assassinate her other progeny. What evidence does she have? How will you stop this assassin?
       - roll: { min: 34, max: 67 }
-        summary: Mortal magic is an emerging threat.
+        summary: There are a few occultists in Santa Maria.
         description: |-
-          Mortals are beginning to harness magic deliberately, posing new challenges for vampires.
+          They’re not that many or that powerful. When they’re organized, they form small groups. This alternative gives access to the Occultist Mortal NPC.
         quest_starter: |-
-          A group of mortal sorcerers forms a pact to hunt vampires. How do you confront them?
+          Occultists are conducting rituals on a beach that belongs to an elder, attracting mortal attention. What do you get in return for stopping them? What do their bizarre rituals involve?
       - roll: { min: 68, max: 100 }
-        summary: Mortal magic rivals vampiric powers.
+        summary: Human beings have no supernatural power.
         description: |-
-          Mortals with magic are formidable adversaries, and some vampires even seek alliances with them.
+          Nothing will happen if they try to cast a spell or perform a ritual.
         quest_starter: |-
-          A mortal magician offers you a powerful enchantment—for a price. What do they demand, and how do you respond?
+          A mortal who claims to be a vampire is being accused of practicing dark magic by their neighbor. Why do you swear to defuse this situation?
+  elegies:
+    name: Elegies
+    type: truth
+    _source:
+      <<: *Source
+      page: 13
+    options:
+      - roll: { min: 1, max: 33 }
+        summary: …are documents written on paper and marked with a drop of blood.
+        description: |-
+          It can be a letter paper, a notebook page or even a napkin. Regardless of the material, it is treated as a contract. After singing an elegy, a vampire sheds a drop of blood on it and hands it to the one to whom she has sworn — or puts it in a safe place if she made the promise to herself.
+        quest_starter: |-
+          Your progenitor writes her elegies in a special paper collection she owns. However, this collection was unfortunately stolen. What will you do to the culprit? Why is this collection so important?
+      - roll: { min: 34, max: 67 }
+        summary: …are made verbally and contemplated in meditation.
+        description: |-
+          Elegies are crafted like any promise, whether written or spoken. The vampire who creates one dedicates a few minutes to half an hour in silence and solitude, concentrating on it and visualizing its fulfillment.
+        quest_starter: |-
+          While you were meditating on an elegy, the vivid image of a vampire smiling at you suddenly appeared in your mind. What strong emotion did this make you feel? Why does her appearance evoke in you a desire to discover who she is?
+      - roll: { min: 68, max: 100 }
+        summary: …are sealed by a bloody handshake.
+        description: |-
+          After a vampire sings an elegy to another individual, each one bites her own palm. They then shake hands, allowing the blood of both to intermingle. When a vampire sings an elegy for herself, she bites both hands and holds them together.
+        quest_starter: |-
+          According to your progenitor, the mummified hand of an ancient vampire is somewhere in Santa Maria.

--- a/source_data/elegy/worlds.yaml
+++ b/source_data/elegy/worlds.yaml
@@ -2,7 +2,7 @@ _id: elegy
 datasworn_version: "0.1.0"
 type: ruleset
 <<: &Source
-  title: 'Elegy 3.5 truths'
+  title: 'Elegy 3.5'
   license: https://creativecommons.org/licenses/by-nc-sa/4.0
   url: https://miraclem.itch.io/elegy
   date: 2024-07-31
@@ -14,6 +14,7 @@ worlds:
     type: world
     _source:
       <<: *Source
+      title: 'Elegy 3.5 truths'
       page: 2
     truths:
       - truth:elegy/history
@@ -27,5 +28,5 @@ worlds:
       - truth:elegy/religion
       - truth:elegy/deviance
       - truth:elegy/werewolves
-      - truth:elegy/elegies
       - truth:elegy/mortal_magic
+      - truth:elegy/elegies


### PR DESCRIPTION
## Summary

- identify the published content as Elegy 3.5 and release the Datasworn package as 0.3.1
- make Elegy self-contained by replacing Classic and Starforged references with local moves and oracles and removing those package dependencies
- audit all moves, oracle tables, assets, truths, rules, impacts, and the Santa Maria world against the supplied Elegy 3.5 PDFs
- restore missing or truncated content, including Lunacy and complete asset abilities
- add validation for local references, expected content counts, oracle ranges, world truth references, and dependency metadata

## Verification

- bun install --frozen-lockfile
- bun run build
- bun run validate
- git diff --check
- generated/dist semantic JSON comparison
- npm pack --dry-run
- isolated Iron Link package-loader smoke test with no Classic or Starforged package installed
- fresh independent content audits for moves/rules, oracles, and assets/truths

PROVENANCE.md is intentionally unchanged.